### PR TITLE
Fix NonObservableLocale lint error in TargetDetailScreen

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/caughtup/ui/TargetDetailScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/ui/TargetDetailScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.unit.dp
 import com.hereliesaz.caughtup.data.Target
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale as ComposeLocale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,7 +48,7 @@ fun TargetDetailScreen(target: Target, onNavigateBack: () -> Unit) {
             )
             
             val dateString = if (target.lastScrapedTimestamp > 0) {
-                SimpleDateFormat("MM/dd/yyyy hh:mm a", Locale.getDefault())
+                SimpleDateFormat("MM/dd/yyyy hh:mm a", ComposeLocale.current.platformLocale)
                     .format(Date(target.lastScrapedTimestamp))
             } else {
                 "Never"


### PR DESCRIPTION
Fix NonObservableLocale lint error in TargetDetailScreen

The build was failing because the `TargetDetailScreen` composable function contained an invocation of `Locale.getDefault()`, which throws a `NonObservableLocale` error. This commit updates it to use the recommended compose specific `Locale` implementation and safely gets the platform locale in a compose context without observable issues.

---
*PR created automatically by Jules for task [6977882381370239379](https://jules.google.com/task/6977882381370239379) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Replace use of Locale.getDefault() with ComposeLocale.current.platformLocale in TargetDetailScreen to satisfy NonObservableLocale lint requirements.