### PR TITLE
Fix Room Main Thread exception

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/caughtup/data/TargetRepository.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/data/TargetRepository.kt
@@ -17,9 +17,25 @@ interface TargetRepository {
 class OfflineTargetRepository(private val targetDao: TargetDao) : TargetRepository {
     override fun getAllTargets(): Flow<List<Target>> = targetDao.getAllTargets()
     override fun getTargetsByStatus(status: TargetStatus): Flow<List<Target>> = targetDao.getTargetsByStatus(status)
-    override suspend fun insertTarget(target: Target) = targetDao.insertTarget(target)
-    override suspend fun insertTargets(targets: List<Target>) = targetDao.insertTargets(targets)
-    override suspend fun updateTarget(target: Target) = targetDao.updateTarget(target)
-    override suspend fun wipeSlateClean() = targetDao.wipeSlateClean()
+    override suspend fun insertTarget(target: Target) {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            targetDao.insertTarget(target)
+        }
+    }
+    override suspend fun insertTargets(targets: List<Target>) {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            targetDao.insertTargets(targets)
+        }
+    }
+    override suspend fun updateTarget(target: Target) {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            targetDao.updateTarget(target)
+        }
+    }
+    override suspend fun wipeSlateClean() {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            targetDao.wipeSlateClean()
+        }
+    }
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/caughtup/ui/TargetDetailScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/ui/TargetDetailScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.unit.dp
 import com.hereliesaz.caughtup.data.Target
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale as ComposeLocale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,7 +48,7 @@ fun TargetDetailScreen(target: Target, onNavigateBack: () -> Unit) {
             )
             
             val dateString = if (target.lastScrapedTimestamp > 0) {
-                SimpleDateFormat("MM/dd/yyyy hh:mm a", Locale.getDefault())
+                SimpleDateFormat("MM/dd/yyyy hh:mm a", ComposeLocale.current.platformLocale)
                     .format(Date(target.lastScrapedTimestamp))
             } else {
                 "Never"


### PR DESCRIPTION
This commit fixes a crash where Room threw an `IllegalStateException` for accessing the database on the main thread during startup because the `insertTargets` call executed synchronously. DAO functions were intentionally left non-suspend due to a Kotlin Symbol Processing (KSP) bug that crashes when they return `Unit`. The fix wraps all synchronous DAO calls inside `withContext(Dispatchers.IO)` in the repository to guarantee execution off the main thread.

## Summary by Sourcery

Ensure database write operations and date formatting behave correctly across threads and platforms.

Bug Fixes:
- Prevent Room from throwing main-thread access exceptions by executing repository write operations on the IO dispatcher.
- Fix locale retrieval for date formatting by using Compose's current platform locale instead of the default Java Locale.