### PR TITLE
Enhance Target Harvester with Residence Info and Smart Searching

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/caughtup/data/CaughtUpDatabase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/data/CaughtUpDatabase.kt
@@ -4,17 +4,25 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
  * The physical manifestation of your localized surveillance state.
  */
-@Database(entities = [Target::class], version = 1, exportSchema = false)
+@Database(entities = [Target::class], version = 2, exportSchema = false)
 abstract class CaughtUpDatabase : RoomDatabase() {
     abstract fun targetDao(): TargetDao
 
     companion object {
         @Volatile
         private var Instance: CaughtUpDatabase? = null
+
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE targets ADD COLUMN residence_info TEXT")
+            }
+        }
 
         fun getDatabase(context: Context): CaughtUpDatabase {
             return Instance ?: synchronized(this) {
@@ -23,6 +31,7 @@ abstract class CaughtUpDatabase : RoomDatabase() {
                     CaughtUpDatabase::class.java,
                     "caughtup_database"
                 )
+                .addMigrations(MIGRATION_1_2)
                 .fallbackToDestructiveMigration()
                 .build()
                 .also { Instance = it }

--- a/app/src/main/kotlin/com/hereliesaz/caughtup/data/ContactHarvester.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/data/ContactHarvester.kt
@@ -13,14 +13,26 @@ import kotlinx.coroutines.withContext
 class ContactHarvester(private val contentResolver: ContentResolver) {
 
     suspend fun harvestContacts(): List<Target> = withContext(Dispatchers.IO) {
-        val targets = mutableListOf<Target>()
+        val contactDataMap = mutableMapOf<Long, ContactData>()
         val projection = arrayOf(
-            ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
-            ContactsContract.CommonDataKinds.Phone.NUMBER
+            ContactsContract.Data.CONTACT_ID,
+            ContactsContract.Data.MIMETYPE,
+            ContactsContract.Data.DATA1, // Often the main data (number, email, street)
+            ContactsContract.Data.DATA2, // Often type
+            ContactsContract.Data.DATA3, // Often label
+            ContactsContract.Data.DATA4,
+            ContactsContract.Data.DATA5,
+            ContactsContract.Data.DATA6,
+            ContactsContract.Data.DATA7,
+            ContactsContract.Data.DATA8,
+            ContactsContract.Data.DATA9,
+            ContactsContract.Data.DATA10,
+            ContactsContract.Contacts.DISPLAY_NAME_PRIMARY,
+            ContactsContract.RawContacts.ACCOUNT_TYPE
         )
 
         val cursor: Cursor? = contentResolver.query(
-            ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+            ContactsContract.Data.CONTENT_URI,
             projection,
             null,
             null,
@@ -28,35 +40,89 @@ class ContactHarvester(private val contentResolver: ContentResolver) {
         )
 
         cursor?.use {
-            val nameIndex = it.getColumnIndex(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)
-            val numberIndex = it.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
+            val idIndex = it.getColumnIndex(ContactsContract.Data.CONTACT_ID)
+            val mimeTypeIndex = it.getColumnIndex(ContactsContract.Data.MIMETYPE)
+            val data1Index = it.getColumnIndex(ContactsContract.Data.DATA1)
+            val nameIndex = it.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY)
+            val accountTypeIndex = it.getColumnIndex(ContactsContract.RawContacts.ACCOUNT_TYPE)
+            val data7Index = it.getColumnIndex(ContactsContract.Data.DATA7) // City
+            val data8Index = it.getColumnIndex(ContactsContract.Data.DATA8) // Region
+            val data9Index = it.getColumnIndex(ContactsContract.Data.DATA9) // Postcode
 
             while (it.moveToNext()) {
-                val name = it.getString(nameIndex) ?: continue
-                val number = it.getString(numberIndex) ?: continue
-                
-                val cleanNumber = number.filter { char -> char.isDigit() }
-                
-                // Naive extraction. Assuming the standard North American numbering plan for now.
-                // We'll have to get clever later if they have international accomplices.
-                val areaCode = if (cleanNumber.length >= 10) {
-                    cleanNumber.takeLast(10).take(3)
-                } else {
-                    "UNKNOWN"
+                val contactId = it.getLong(idIndex)
+                if (contactId <= 0) continue
+
+                val mimeType = it.getString(mimeTypeIndex)
+                val displayName = it.getString(nameIndex) ?: continue
+                val accountType = it.getString(accountTypeIndex)
+
+                val contactData = contactDataMap.getOrPut(contactId) { ContactData(displayName) }
+
+                if (accountType != null) {
+                    val mappedAccount = when {
+                        accountType.contains("google", ignoreCase = true) -> "Google"
+                        accountType.contains("facebook", ignoreCase = true) -> "Facebook"
+                        accountType.contains("whatsapp", ignoreCase = true) -> "WhatsApp"
+                        accountType.contains("apple", ignoreCase = true) -> "Apple"
+                        else -> "Device Contacts"
+                    }
+                    contactData.accounts.add(mappedAccount)
                 }
 
-                targets.add(
-                    Target(
-                        displayName = name,
-                        phoneNumber = number,
-                        areaCode = areaCode,
-                        sourceAccount = "Device Contacts"
-                    )
-                )
+                when (mimeType) {
+                    ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE -> {
+                        val number = it.getString(data1Index)
+                        if (number != null && contactData.phoneNumber == null) {
+                            contactData.phoneNumber = number
+                        }
+                    }
+                    ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE -> {
+                        val city = it.getString(data7Index)
+                        val region = it.getString(data8Index)
+                        val zip = it.getString(data9Index)
+
+                        val locationParts = listOfNotNull(city, region, zip).filter { part -> part.isNotBlank() }
+                        if (locationParts.isNotEmpty() && contactData.residenceInfo == null) {
+                            contactData.residenceInfo = locationParts.joinToString(", ")
+                        }
+                    }
+                }
             }
         }
         
+        val targets = contactDataMap.values.mapNotNull { data ->
+            val number = data.phoneNumber ?: return@mapNotNull null
+            val cleanNumber = number.filter { char -> char.isDigit() }
+            val areaCode = if (cleanNumber.length >= 10) {
+                cleanNumber.takeLast(10).take(3)
+            } else {
+                "UNKNOWN"
+            }
+
+            val sourceAccounts = if (data.accounts.isEmpty()) {
+                "Device Contacts"
+            } else {
+                data.accounts.joinToString(", ")
+            }
+
+            Target(
+                displayName = data.displayName,
+                phoneNumber = number,
+                areaCode = areaCode,
+                sourceAccount = sourceAccounts,
+                residenceInfo = data.residenceInfo
+            )
+        }
+
         targets.distinctBy { it.phoneNumber }
     }
+
+    private class ContactData(
+        val displayName: String,
+        var phoneNumber: String? = null,
+        var residenceInfo: String? = null,
+        val accounts: MutableSet<String> = mutableSetOf()
+    )
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/caughtup/data/Target.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/data/Target.kt
@@ -21,7 +21,9 @@ data class Target(
     @ColumnInfo(name = "last_scraped_timestamp")
     val lastScrapedTimestamp: Long = 0L,
     @ColumnInfo(name = "source_account")
-    val sourceAccount: String? = null
+    val sourceAccount: String? = null,
+    @ColumnInfo(name = "residence_info")
+    val residenceInfo: String? = null
 )
 
 enum class TargetStatus {

--- a/app/src/main/kotlin/com/hereliesaz/caughtup/network/JurisdictionMapper.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/network/JurisdictionMapper.kt
@@ -6,7 +6,21 @@ package com.hereliesaz.caughtup.network
  */
 class JurisdictionMapper {
 
-    fun getLockupUrl(areaCode: String): String? {
+    fun getLockupUrl(areaCode: String, residenceInfo: String? = null): String? {
+        val lowerResidence = residenceInfo?.lowercase() ?: ""
+
+        if (lowerResidence.contains("new orleans") || Regex("\\bla\\b").containsMatchIn(lowerResidence) || lowerResidence.contains("louisiana")) {
+             if (areaCode == "504" || lowerResidence.contains("new orleans")) {
+                 return "https://opso.us/docket/"
+             }
+             if (areaCode == "985" || lowerResidence.contains("st. tammany") || lowerResidence.contains("covington") || lowerResidence.contains("slidell")) {
+                 return "https://www.stpso.com/inmate-roster/"
+             }
+             if (areaCode == "225" || lowerResidence.contains("baton rouge")) {
+                 return "https://www.brla.gov/prison/"
+             }
+        }
+
         return when (areaCode) {
             "504" -> "https://opso.us/docket/"
             "985" -> "https://www.stpso.com/inmate-roster/" // Just in case they fled across the lake.
@@ -15,7 +29,15 @@ class JurisdictionMapper {
         }
     }
 
-    fun getObituaryUrl(areaCode: String): String? {
+    fun getObituaryUrl(areaCode: String, residenceInfo: String? = null): String? {
+         val lowerResidence = residenceInfo?.lowercase() ?: ""
+
+         if (lowerResidence.contains("new orleans") || Regex("\\bla\\b").containsMatchIn(lowerResidence) || lowerResidence.contains("louisiana")) {
+             if (areaCode == "504" || lowerResidence.contains("new orleans")) {
+                 return "https://obits.nola.com/us/obituaries/nola/browse"
+             }
+         }
+
          return when (areaCode) {
             "504" -> "https://obits.nola.com/us/obituaries/nola/browse"
             else -> null

--- a/app/src/main/kotlin/com/hereliesaz/caughtup/ui/TargetDetailScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/ui/TargetDetailScreen.kt
@@ -3,10 +3,14 @@ package com.hereliesaz.caughtup.ui
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.caughtup.data.Target
+import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -14,6 +18,7 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TargetDetailScreen(target: Target, onNavigateBack: () -> Unit) {
+    val context = LocalContext.current
     Scaffold(
         topBar = {
             TopAppBar(
@@ -42,19 +47,40 @@ fun TargetDetailScreen(target: Target, onNavigateBack: () -> Unit) {
 
             DetailRow(label = "Primary Identifier", value = target.phoneNumber)
             DetailRow(label = "Geographic Anchor", value = target.areaCode)
+            if (!target.residenceInfo.isNullOrBlank()) {
+                DetailRow(label = "Known Residence", value = target.residenceInfo)
+            }
             DetailRow(
                 label = "Current State of Being", 
                 value = target.status.name.replace("_", " ")
             )
             
             val dateString = if (target.lastScrapedTimestamp > 0) {
-                SimpleDateFormat("MM/dd/yyyy hh:mm a", Locale.getDefault())
+                SimpleDateFormat("MM/dd/yyyy hh:mm a", java.util.Locale.US)
                     .format(Date(target.lastScrapedTimestamp))
             } else {
                 "Never"
             }
             DetailRow(label = "Last Interrogation of the Void", value = dateString)
             DetailRow(label = "Extraction Source", value = target.sourceAccount ?: "Unknown")
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = {
+                    try {
+                        val query = "${target.displayName} ${target.residenceInfo ?: ""}".trim()
+                        val encodedQuery = URLEncoder.encode(query, "UTF-8")
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://news.google.com/search?q=$encodedQuery"))
+                        context.startActivity(intent)
+                    } catch (e: android.content.ActivityNotFoundException) {
+                        // Ignore if no web browser is installed
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("General News Search")
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/caughtup/worker/ScrapingWorker.kt
+++ b/app/src/main/kotlin/com/hereliesaz/caughtup/worker/ScrapingWorker.kt
@@ -32,7 +32,7 @@ class ScrapingWorker(
             var newStatus = TargetStatus.AT_LARGE
 
             // 1. Interrogate the municipal cages
-            val lockupUrl = mapper.getLockupUrl(target.areaCode)
+            val lockupUrl = mapper.getLockupUrl(target.areaCode, target.residenceInfo)
             if (lockupUrl != null) {
                 val isIncarcerated = basicScraper.scrapeMugshots(lockupUrl, target.displayName)
                 if (isIncarcerated) {
@@ -42,7 +42,7 @@ class ScrapingWorker(
 
             // 2. If they aren't in a cell, check if they are in the ground
             if (newStatus == TargetStatus.AT_LARGE) {
-                val obitUrl = mapper.getObituaryUrl(target.areaCode)
+                val obitUrl = mapper.getObituaryUrl(target.areaCode, target.residenceInfo)
                 if (obitUrl != null) {
                     val obitDoc = stealthScraper.scrapeGhostTown(obitUrl)
                     val textToSearch = obitDoc?.text() ?: ""


### PR DESCRIPTION
Harvests richer contact data including residence info and source accounts, uses residence info to improve municipal/obituary URL mapping, and adds a general news search feature.

---
*PR created automatically by Jules for task [15758409426905308726](https://jules.google.com/task/15758409426905308726) started by @HereLiesAz*

## Summary by Sourcery

Extend contact harvesting, persistence, and downstream processing to include residence information and richer source metadata, and surface this data in the UI with a new news search action.

New Features:
- Harvest and store contact residence information and originating account types when building targets from the device address book.
- Display known residence details on the target detail screen and provide a one-tap general news search using the target's name and location.
- Use residence information alongside area code when mapping to municipal lockup and obituary sources to improve jurisdiction selection.

Enhancements:
- Expand contact harvesting to aggregate per-contact data across multiple rows and accounts and to support multiple source accounts per target.
- Introduce a Room database migration to add a residence_info column to targets without destructive data loss.