### PR TITLE
Wire probabilistic matcher into dedup, fix Kotlin 2.4.0 Hilt build break, add match tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,17 @@ kotlin {
     jvmToolchain(21)
 }
 
+// Hilt/Dagger's annotation processor reads Kotlin class metadata via kotlin-metadata-jvm.
+// The version Dagger bundles trails the compiler, so once the project moved to Kotlin 2.4.0 the
+// aggregating `hiltJavaCompile*` task failed with "Provided Metadata instance has version 2.4.0,
+// while maximum supported version is 2.3.0". Force the parser to match the Kotlin we compile with
+// so it can read the metadata we emit. Kept in lockstep with the catalog's `kotlin` version.
+configurations.configureEach {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-metadata-jvm:${libs.versions.kotlin.get()}")
+    }
+}
+
 android {
     namespace = "com.hereliesaz.cleanunderwear"
     compileSdk = 37

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCase.kt
@@ -3,39 +3,60 @@ package com.hereliesaz.cleanunderwear.domain
 import com.hereliesaz.cleanunderwear.data.Target
 import com.hereliesaz.cleanunderwear.data.TargetLite
 import com.hereliesaz.cleanunderwear.data.TargetRepository
+import com.hereliesaz.cleanunderwear.match.MatchRecord
+import com.hereliesaz.cleanunderwear.match.ProbabilisticScorer
+import com.hereliesaz.cleanunderwear.match.StringSimilarity
 import com.hereliesaz.cleanunderwear.util.DiagnosticLogger
 import javax.inject.Inject
 
 /**
  * Walks the entire repository and merges duplicate Targets into one canonical record per
- * identity. Two Targets collide when they share a normalized phone number, an email, or
- * (when neither is present) a normalized display name.
+ * identity.
  *
- * The first pass uses [TargetLite] so we never load the heavy verification-snippet/URL columns
- * for the bulk of rows that won't collide. Only collision groups get hydrated to full [Target]
- * rows for the merge.
+ * The cheap first pass uses [TargetLite] so we never load the heavy verification-snippet/URL
+ * columns for the bulk of rows that won't collide. Sharing a normalized phone, email, or
+ * (when neither is present) display name only makes two rows *candidates*; it does not, on its
+ * own, mean they are the same person.
  *
- * The "winning" record is whichever lite row has the most non-null intel fields (with a small
- * deference to the row with the freshest scrape); the loser's unique fields are merged into
- * the winner before the loser is deleted.
+ * The actual merge decision is delegated to the [ProbabilisticScorer]. A recycled phone number
+ * shared by two people whose surnames clearly differ, or a pair of rows that agree on nothing
+ * but a common name, no longer force-merge strangers — they are left apart for a human. Within
+ * each candidate block we therefore partition the rows into *confident-match components* (rows
+ * the scorer rates [com.hereliesaz.cleanunderwear.match.MatchDecision.MATCH] connect; everything
+ * weaker stays separate) and merge only inside each component.
+ *
+ * The scorer's frequency down-weighting is fed by corpus-wide counts gathered during the scan,
+ * so agreeing on a *rare* value keeps full weight while agreeing on a common one ("John Smith",
+ * a recycled number) is penalised by its self-information. That is what makes a name-only
+ * collision resolve to "not enough data" instead of a wrong merge.
+ *
+ * The "winning" record within a component is whichever full row carries the most intel; the
+ * losers' unique fields are merged into the winner before the losers are deleted.
  */
 class DeduplicateTargetsUseCase @Inject constructor(
     private val repository: TargetRepository
 ) {
     suspend operator fun invoke(onProgress: (Float, String) -> Unit = { _, _ -> }): Int {
         val groups = mutableMapOf<String, MutableList<Int>>() // identityKey -> list of IDs
-        
+
+        // Corpus-wide value counts that drive the scorer's frequency down-weighting. Gathered
+        // in the same chunked pass that builds the candidate blocks so we never re-scan.
+        val phoneFreq = HashMap<String, Int>()
+        val emailFreq = HashMap<String, Int>()
+        val surnameFreq = HashMap<String, Int>()
+
         var offset = 0
         val chunkSize = 1000
-        
+
         // 1. Identify collision candidates using memory-efficient chunking
         while (true) {
             val chunk = repository.getTargetsPaged(chunkSize, offset)
             if (chunk.isEmpty()) break
-            
+
             for (t in chunk) {
                 val key = identityKey(t)
                 groups.getOrPut(key) { mutableListOf() }.add(t.id)
+                tallyFrequencies(t, phoneFreq, emailFreq, surnameFreq)
             }
             offset += chunkSize
             onProgress(0.1f, "Scanning registry for duplicates ($offset)...")
@@ -47,35 +68,126 @@ class DeduplicateTargetsUseCase @Inject constructor(
             return 0
         }
 
+        val scorer = ProbabilisticScorer(
+            frequency = { field, value ->
+                when (field) {
+                    "phone" -> phoneFreq[value] ?: 1
+                    "email" -> emailFreq[value] ?: 1
+                    "surname" -> surnameFreq[value] ?: 1
+                    else -> 1
+                }
+            }
+        )
+
         var processed = 0
         var merged = 0
+        var ambiguousSkipped = 0
         val totalSteps = collisions.size
 
-        // 2. Resolve collisions (only hydrating full rows for actual duplicates)
+        // 2. Resolve collisions (only hydrating full rows for actual candidates)
         for (idGroup in collisions) {
             val fullGroup = repository.getTargetsByIds(idGroup)
             if (fullGroup.size < 2) continue
-            
-            val winner = pickWinnerFull(fullGroup)
-            val losers = fullGroup.filter { it.id != winner.id }
-            
-            val mergedFull = losers.fold(winner) { acc, loser -> mergeFields(acc, loser) }
-            repository.updateTarget(mergedFull)
-            for (loser in losers) {
-                repository.deleteTarget(loser)
-                merged++
+
+            if (fullGroup.size > MAX_PAIRWISE_GROUP) {
+                // A block this large is a low-quality collision (a recycled value or a very
+                // common name shared by many rows). Pairwise scoring would be O(n^2) and these
+                // are exactly the rows we must not blindly fuse — leave them for manual review.
+                ambiguousSkipped += fullGroup.size
+                processed++
+                onProgress(processed.toFloat() / totalSteps, "Skipping ambiguous block (${fullGroup.size} rows)...")
+                continue
+            }
+
+            for (component in confidentMatchComponents(fullGroup, scorer)) {
+                if (component.size < 2) continue
+
+                val winner = pickWinnerFull(component)
+                val losers = component.filter { it.id != winner.id }
+                val mergedFull = losers.fold(winner) { acc, loser -> mergeFields(acc, loser) }
+                repository.updateTarget(mergedFull)
+                for (loser in losers) {
+                    repository.deleteTarget(loser)
+                    merged++
+                }
             }
 
             processed++
             onProgress(
                 processed.toFloat() / totalSteps,
-                "Merging duplicates: ${winner.displayName}"
+                "Resolving duplicates ($processed/$totalSteps)..."
             )
         }
 
-        DiagnosticLogger.log("Dedup: collapsed $merged duplicate row(s) across $totalSteps identities")
+        DiagnosticLogger.log(
+            "Dedup: collapsed $merged duplicate row(s) across $totalSteps candidate identities" +
+                if (ambiguousSkipped > 0) "; left $ambiguousSkipped row(s) in oversized blocks for review" else ""
+        )
         return merged
     }
+
+    /**
+     * Partition a candidate block into components of rows the scorer is confident denote one
+     * person. Two rows join the same component when [ProbabilisticScorer.score] returns
+     * [com.hereliesaz.cleanunderwear.match.MatchDecision.MATCH]; weaker verdicts leave them in
+     * separate components so they are never merged. Union-find keeps transitive merges correct
+     * (A~B and B~C collapse A, B, C together).
+     */
+    private fun confidentMatchComponents(
+        group: List<Target>,
+        scorer: ProbabilisticScorer
+    ): List<List<Target>> {
+        val n = group.size
+        val parent = IntArray(n) { it }
+
+        fun find(x: Int): Int {
+            var root = x
+            while (parent[root] != root) root = parent[root]
+            var cur = x
+            while (parent[cur] != cur) {
+                val next = parent[cur]
+                parent[cur] = root
+                cur = next
+            }
+            return root
+        }
+
+        fun union(a: Int, b: Int) {
+            parent[find(a)] = find(b)
+        }
+
+        val records = group.map { toMatchRecord(it) }
+        for (i in 0 until n) {
+            for (j in i + 1 until n) {
+                if (scorer.score(records[i], records[j]).isConfidentMatch) union(i, j)
+            }
+        }
+
+        return group.indices.groupBy { find(it) }.values.map { idxs -> idxs.map { group[it] } }
+    }
+
+    private fun toMatchRecord(t: Target): MatchRecord = MatchRecord.fromDisplayName(
+        displayName = t.displayName,
+        phone = t.phoneNumber,
+        email = t.email,
+        address = t.residenceInfo,
+        areaCode = t.areaCode
+    )
+
+    private fun tallyFrequencies(
+        t: TargetLite,
+        phoneFreq: MutableMap<String, Int>,
+        emailFreq: MutableMap<String, Int>,
+        surnameFreq: MutableMap<String, Int>
+    ) {
+        StringSimilarity.normalizePhone(t.phoneNumber)?.let { phoneFreq.merge(it, 1, Int::plus) }
+        StringSimilarity.normalizeEmail(t.email)?.let { emailFreq.merge(it, 1, Int::plus) }
+        surnameKey(t.displayName)?.let { surnameFreq.merge(it, 1, Int::plus) }
+    }
+
+    /** Surname frequency key, normalized identically to the scorer's surname down-weight lookup. */
+    private fun surnameKey(displayName: String): String? =
+        StringSimilarity.normalizeNameToken(MatchRecord.fromDisplayName(displayName).lastName)
 
     private fun pickWinnerFull(group: List<Target>): Target {
         return group.maxByOrNull { fullFieldScore(it) } ?: group.first()
@@ -131,5 +243,10 @@ class DeduplicateTargetsUseCase @Inject constructor(
         a?.split(", ")?.forEach { if (it.isNotBlank()) parts += it.trim() }
         b?.split(", ")?.forEach { if (it.isNotBlank()) parts += it.trim() }
         return if (parts.isEmpty()) null else parts.joinToString(", ")
+    }
+
+    private companion object {
+        /** Above this candidate-block size we skip pairwise scoring and leave rows for review. */
+        const val MAX_PAIRWISE_GROUP = 500
     }
 }

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCaseTest.kt
@@ -1,0 +1,134 @@
+package com.hereliesaz.cleanunderwear.domain
+
+import androidx.paging.PagingSource
+import com.hereliesaz.cleanunderwear.data.MonitorabilityState
+import com.hereliesaz.cleanunderwear.data.Target
+import com.hereliesaz.cleanunderwear.data.TargetLite
+import com.hereliesaz.cleanunderwear.data.TargetRepository
+import com.hereliesaz.cleanunderwear.data.TargetSourceInfo
+import com.hereliesaz.cleanunderwear.data.TargetStatus
+import com.hereliesaz.cleanunderwear.data.TargetWorkInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeduplicateTargetsUseCaseTest {
+
+    /** In-memory repository exercising only the reads/mutations the use case touches. */
+    private class FakeRepository(initial: List<Target>) : TargetRepository {
+        val store = initial.toMutableList()
+
+        private fun lite(t: Target) = TargetLite(
+            id = t.id,
+            displayName = t.displayName,
+            phoneNumber = t.phoneNumber,
+            areaCode = t.areaCode,
+            status = t.status,
+            email = t.email,
+            lastStatusChangeTimestamp = t.lastStatusChangeTimestamp,
+            lastScrapedTimestamp = t.lastScrapedTimestamp
+        )
+
+        override suspend fun getTargetsPaged(limit: Int, offset: Int): List<TargetLite> =
+            store.drop(offset).take(limit).map(::lite)
+
+        override suspend fun getTargetsByIds(ids: List<Int>): List<Target> =
+            store.filter { it.id in ids }
+
+        override suspend fun updateTarget(target: Target) {
+            val idx = store.indexOfFirst { it.id == target.id }
+            if (idx >= 0) store[idx] = target
+        }
+
+        override suspend fun deleteTarget(target: Target) {
+            store.removeAll { it.id == target.id }
+        }
+
+        // --- Unused by dedup ---
+        override fun getAllTargetsLite(): Flow<List<TargetLite>> = throw NotImplementedError()
+        override fun searchTargets(
+            query: String, showIgnored: Boolean, googleF: Boolean?, metaF: Boolean?,
+            appleF: Boolean?, deviceF: Boolean?, namelessF: Boolean?, emailOnlyF: Boolean?,
+            hasEmailF: Boolean?, hasAddressF: Boolean?, pendingEnrichF: Boolean?, sort: String
+        ): PagingSource<Int, TargetLite> = throw NotImplementedError()
+        override suspend fun getTargetWorkInfoPaged(limit: Int, offset: Int): List<TargetWorkInfo> = throw NotImplementedError()
+        override suspend fun getAllTargetSourceInfo(): List<TargetSourceInfo> = throw NotImplementedError()
+        override suspend fun getTargetById(id: Int): Target? = throw NotImplementedError()
+        override fun observeTargetById(id: Int): Flow<Target?> = throw NotImplementedError()
+        override suspend fun getTargetsByMonitorability(state: MonitorabilityState): List<Target> = throw NotImplementedError()
+        override suspend fun getReadyDueTargets(now: Long): List<Target> = throw NotImplementedError()
+        override fun getAllTargets(): Flow<List<Target>> = throw NotImplementedError()
+        override fun getTargetsByStatus(status: TargetStatus): Flow<List<Target>> = throw NotImplementedError()
+        override suspend fun updateMonitorabilityState(id: Int, state: MonitorabilityState) = throw NotImplementedError()
+        override suspend fun updateMonitorabilityStateBatch(ids: List<Int>, state: MonitorabilityState) = throw NotImplementedError()
+        override suspend fun updateStatusOnly(id: Int, status: TargetStatus, timestamp: Long) = throw NotImplementedError()
+        override suspend fun updateUrls(id: Int, lockupUrl: String?, obituaryUrl: String?) = throw NotImplementedError()
+        override suspend fun insertTarget(target: Target) = throw NotImplementedError()
+        override suspend fun insertTargets(targets: List<Target>) = throw NotImplementedError()
+        override suspend fun wipeSlateClean() = throw NotImplementedError()
+    }
+
+    @Test
+    fun samePhoneAndName_areMerged() = runTest {
+        val repo = FakeRepository(
+            listOf(
+                Target(id = 1, displayName = "John Smith", phoneNumber = "555-123-4567"),
+                Target(id = 2, displayName = "John Smith", phoneNumber = "(555) 123-4567")
+            )
+        )
+
+        val merged = DeduplicateTargetsUseCase(repo).invoke()
+
+        assertEquals(1, merged)
+        assertEquals(1, repo.store.size)
+    }
+
+    @Test
+    fun recycledPhoneWithConflictingNames_areNotMerged() = runTest {
+        // Same number, clearly different people — blocking proposes them, the scorer keeps them apart.
+        val repo = FakeRepository(
+            listOf(
+                Target(id = 1, displayName = "John Smith", phoneNumber = "555-123-4567"),
+                Target(id = 2, displayName = "Maria Gonzalez", phoneNumber = "555-123-4567")
+            )
+        )
+
+        val merged = DeduplicateTargetsUseCase(repo).invoke()
+
+        assertEquals(0, merged)
+        assertEquals(2, repo.store.size)
+    }
+
+    @Test
+    fun nameOnlyCollision_isNotMerged() = runTest {
+        // No corroborating phone/email/address — a name alone is never enough to auto-merge.
+        val repo = FakeRepository(
+            listOf(
+                Target(id = 1, displayName = "John Smith"),
+                Target(id = 2, displayName = "John Smith")
+            )
+        )
+
+        val merged = DeduplicateTargetsUseCase(repo).invoke()
+
+        assertEquals(0, merged)
+        assertEquals(2, repo.store.size)
+    }
+
+    @Test
+    fun threeWaySharedPhone_collapseTransitively() = runTest {
+        val repo = FakeRepository(
+            listOf(
+                Target(id = 1, displayName = "John Smith", phoneNumber = "555-123-4567"),
+                Target(id = 2, displayName = "John Smith", phoneNumber = "555-123-4567"),
+                Target(id = 3, displayName = "John Smith", phoneNumber = "555-123-4567")
+            )
+        )
+
+        val merged = DeduplicateTargetsUseCase(repo).invoke()
+
+        assertEquals(2, merged)
+        assertEquals(1, repo.store.size)
+    }
+}

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/match/ProbabilisticScorerTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/match/ProbabilisticScorerTest.kt
@@ -1,0 +1,112 @@
+package com.hereliesaz.cleanunderwear.match
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavioural contract for the cold-start scorer. These tests pin the safety properties the
+ * rest of the app relies on: a shared (possibly recycled) phone never auto-merges people whose
+ * names contradict, a common name alone is "not enough data", and only genuinely corroborating
+ * evidence reaches a confident MATCH.
+ */
+class ProbabilisticScorerTest {
+
+    private val scorer = ProbabilisticScorer()
+
+    @Test
+    fun samePhoneAndName_isConfidentMatch() {
+        val a = MatchRecord.fromDisplayName("John Smith", phone = "555-123-4567")
+        val b = MatchRecord.fromDisplayName("John Smith", phone = "(555) 123-4567")
+
+        val verdict = scorer.score(a, b)
+
+        assertEquals(MatchDecision.MATCH, verdict.decision)
+        assertTrue(verdict.isConfidentMatch)
+    }
+
+    @Test
+    fun sameEmail_isConfidentMatch() {
+        val a = MatchRecord.fromDisplayName("John Smith", email = "jsmith@example.com")
+        val b = MatchRecord.fromDisplayName("John Smith", email = "JSmith@Example.com")
+
+        assertEquals(MatchDecision.MATCH, scorer.score(a, b).decision)
+    }
+
+    @Test
+    fun sharedPhoneButConflictingSurnames_isReviewNotMatch() {
+        // The recycled-number case: a shared phone is strong evidence, but two clearly different
+        // surnames must keep this out of an auto-merge and in front of a human.
+        val a = MatchRecord.fromDisplayName("John Smith", phone = "555-123-4567")
+        val b = MatchRecord.fromDisplayName("John Jones", phone = "555-123-4567")
+
+        val verdict = scorer.score(a, b)
+
+        assertEquals(MatchDecision.REVIEW, verdict.decision)
+        assertFalse(verdict.isConfidentMatch)
+    }
+
+    @Test
+    fun commonSurnameNameOnly_isInsufficient() {
+        // "Two John Smiths with nothing else in common come back INSUFFICIENT, not MATCH."
+        val frequentSmith = ProbabilisticScorer(
+            frequency = { field, value -> if (field == "surname" && value == "smith") 50 else 1 }
+        )
+        val a = MatchRecord.fromDisplayName("John Smith")
+        val b = MatchRecord.fromDisplayName("John Smith")
+
+        assertEquals(MatchDecision.INSUFFICIENT, frequentSmith.score(a, b).decision)
+    }
+
+    @Test
+    fun rareSurnameNameOnly_stillNotAutoMerged() {
+        // Even an uncommon name, with no corroborating field, must not auto-merge on its own.
+        val rare = ProbabilisticScorer(
+            frequency = { field, value -> if (field == "surname" && value == "quillon") 2 else 1 }
+        )
+        val a = MatchRecord.fromDisplayName("Zephyr Quillon")
+        val b = MatchRecord.fromDisplayName("Zephyr Quillon")
+
+        assertFalse(rare.score(a, b).isConfidentMatch)
+    }
+
+    @Test
+    fun firstNamesOnly_isInsufficient() {
+        val a = MatchRecord(firstName = "John")
+        val b = MatchRecord(firstName = "John")
+
+        assertEquals(MatchDecision.INSUFFICIENT, scorer.score(a, b).decision)
+    }
+
+    @Test
+    fun conflictingSurnamesNoOtherEvidence_isNoMatch() {
+        val a = MatchRecord.fromDisplayName("John Smith")
+        val b = MatchRecord.fromDisplayName("John Jones")
+
+        assertEquals(MatchDecision.NO_MATCH, scorer.score(a, b).decision)
+    }
+
+    @Test
+    fun nicknameVariantSurnameMatch_isConfidentMatch() {
+        val nicknamed = ProbabilisticScorer(nicknames = { name ->
+            if (name == "jim") listOf("james") else emptyList()
+        })
+        val a = MatchRecord(firstName = "Jim", lastName = "Smith")
+        val b = MatchRecord(firstName = "James", lastName = "Smith")
+
+        assertEquals(MatchDecision.MATCH, nicknamed.score(a, b).decision)
+    }
+
+    @Test
+    fun verdictCarriesPerFieldAuditTrail() {
+        val a = MatchRecord.fromDisplayName("John Smith", phone = "555-123-4567")
+        val b = MatchRecord.fromDisplayName("John Smith", phone = "555-123-4567")
+
+        val verdict = scorer.score(a, b)
+
+        assertTrue(verdict.contributions.any { it.field == "phone" })
+        assertTrue(verdict.contributions.any { it.field == "name" })
+        assertTrue(verdict.probability in 0.0..1.0)
+    }
+}

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/match/StringSimilarityTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/match/StringSimilarityTest.kt
@@ -1,0 +1,93 @@
+package com.hereliesaz.cleanunderwear.match
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StringSimilarityTest {
+
+    @Test
+    fun jaroWinkler_identicalStrings_isOne() {
+        assertEquals(1.0, StringSimilarity.jaroWinkler("smith", "smith"), 0.0)
+    }
+
+    @Test
+    fun jaroWinkler_isCaseInsensitive() {
+        assertEquals(1.0, StringSimilarity.jaroWinkler("Smith", "SMITH"), 0.0)
+    }
+
+    @Test
+    fun jaroWinkler_nearTypo_scoresHigh() {
+        // A single-letter swap on a shared prefix should stay well above the matcher's 0.90 bar.
+        assertTrue(StringSimilarity.jaroWinkler("smith", "smyth") >= 0.85)
+    }
+
+    @Test
+    fun jaroWinkler_unrelatedStrings_scoreLow() {
+        assertTrue(StringSimilarity.jaroWinkler("smith", "jones") < 0.7)
+    }
+
+    @Test
+    fun jaroWinkler_emptyString_isZero() {
+        assertEquals(0.0, StringSimilarity.jaroWinkler("smith", ""), 0.0)
+    }
+
+    @Test
+    fun normalizePhone_stripsFormattingAndLeadingOne() {
+        assertEquals("5551234567", StringSimilarity.normalizePhone("+1 (555) 123-4567"))
+    }
+
+    @Test
+    fun normalizePhone_tooShort_isNull() {
+        assertNull(StringSimilarity.normalizePhone("555-1234"))
+    }
+
+    @Test
+    fun normalizePhone_blankOrNull_isNull() {
+        assertNull(StringSimilarity.normalizePhone(null))
+        assertNull(StringSimilarity.normalizePhone("   "))
+    }
+
+    @Test
+    fun normalizeEmail_trimsAndLowercases() {
+        assertEquals("john@example.com", StringSimilarity.normalizeEmail("  John@Example.COM "))
+    }
+
+    @Test
+    fun normalizeEmail_withoutAtSign_isNull() {
+        assertNull(StringSimilarity.normalizeEmail("not-an-email"))
+    }
+
+    @Test
+    fun normalizeNameToken_keepsLettersHyphenApostrophe() {
+        assertEquals("o'brien-smith", StringSimilarity.normalizeNameToken("  O'Brien-Smith  "))
+    }
+
+    @Test
+    fun extractZip_findsFiveDigitZip() {
+        assertEquals("62704", StringSimilarity.extractZip("123 Main St, Springfield, IL 62704"))
+    }
+
+    @Test
+    fun extractZip_handlesZipPlusFour() {
+        assertEquals("62704", StringSimilarity.extractZip("Springfield IL 62704-1234"))
+    }
+
+    @Test
+    fun extractZip_noZip_isNull() {
+        assertNull(StringSimilarity.extractZip("Springfield, Illinois"))
+    }
+
+    @Test
+    fun streetTokens_foldsSuffixesAndUsesFirstSegment() {
+        val tokens = StringSimilarity.streetTokens("123 Main St, Springfield, IL")
+        assertEquals(setOf("123", "main", "street"), tokens)
+    }
+
+    @Test
+    fun streetTokens_blank_isEmpty() {
+        assertTrue(StringSimilarity.streetTokens(null).isEmpty())
+        assertTrue(StringSimilarity.streetTokens("").isEmpty())
+    }
+}


### PR DESCRIPTION
## Why

The previous session added the entity-resolution engine (`ProbabilisticScorer`, `MatchRecord`, `StringSimilarity`) but left two things undone:

1. **The engine was never consumed.** `DeduplicateTargetsUseCase` still hard-keyed on exact phone/email/name and blindly merged every row in a collision group.
2. **The build no longer compiled.** The same commit bumped Kotlin `2.3.21 → 2.4.0`, but Dagger/Hilt's bundled `kotlin-metadata-jvm` only parses class metadata up to `2.3.0`, so `hiltJavaCompile*` failed:
   > Provided Metadata instance has version 2.4.0, while maximum supported version is 2.3.0.

   (This break is already on `main`.)

## What

### Toolchain fix
Force `org.jetbrains.kotlin:kotlin-metadata-jvm` to the catalog's Kotlin version on every configuration, so Dagger's annotation processor can read the metadata the compiler emits. Kept in lockstep with the `kotlin` version so the next bump doesn't reintroduce the skew. No runtime/APK impact (processor-classpath only).

### Dedup integration
`DeduplicateTargetsUseCase` now delegates the merge decision to `ProbabilisticScorer`:

- Sharing a phone/email/name only makes two rows **candidates**. The scorer decides which actually denote one person.
- A **recycled phone** shared by people whose surnames conflict → left apart (REVIEW), not merged.
- A pair agreeing on nothing but a **common name** → "not enough data", not merged.
- Candidate blocks are partitioned into confident-match **components** via union-find (transitive merges stay correct) and merged only within each component.
- Corpus-wide phone/email/surname counts gathered during the existing chunked scan feed the scorer's **frequency down-weighting** — agreeing on a rare value keeps full weight; a common one is penalised.
- Oversized low-quality blocks (>500 rows) are left for manual review instead of an O(n²) blind fuse.

**Behaviour change worth flagging:** name-only duplicates with no corroborating phone/email/address are no longer auto-merged. That is the engine's intended safety stance (a name alone is never sufficient), and it fixes a latent correctness bug where distinct people sharing a common name were silently fused.

### Tests (29, all green)
- `StringSimilarityTest` (16) — Jaro-Winkler, phone/email/name normalization, ZIP + street tokens.
- `ProbabilisticScorerTest` (9) — the behavioural contract, including the recycled-phone-conflicting-surname and common-name-insufficient safety properties.
- `DeduplicateTargetsUseCaseTest` (4) — end-to-end over a fake repository: real dup merges, recycled phone doesn't, name-only doesn't, three-way shared phone collapses transitively.

## Verification
`./gradlew :app:testDebugUnitTest` — **BUILD SUCCESSFUL**, full suite passing (the new 29 plus all pre-existing tests).

https://claude.ai/code/session_01QdU7CsF92St1PznNqwqw5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdU7CsF92St1PznNqwqw5v)_

## Summary by Sourcery

Integrate the probabilistic entity-resolution engine into the target deduplication flow, tighten safety around automatic merges, and restore Kotlin 2.4.0 Hilt builds while adding coverage for matching and dedup behaviour.

New Features:
- Use a probabilistic scorer to decide which candidate target records should be merged instead of relying solely on shared phone, email, or name.
- Partition candidate collision groups into confident-match components to support transitive merges while leaving ambiguous cases unmerged.

Bug Fixes:
- Prevent incorrect auto-merges for records that only share a common name or a recycled phone number with conflicting surnames.
- Fix Kotlin 2.4.0 build failures by forcing kotlin-metadata-jvm to the catalog Kotlin version for Hilt/Dagger annotation processing.

Enhancements:
- Collect corpus-wide phone, email, and surname frequencies during deduplication scanning to feed frequency-aware down-weighting in the probabilistic scorer.
- Skip very large, low-quality collision blocks from pairwise scoring and log how many rows are left for manual review.

Tests:
- Add unit tests for the probabilistic scorer’s decision logic and safety properties around shared phones and common names.
- Add unit tests for string similarity utilities including Jaro-Winkler and normalization helpers.
- Add end-to-end tests for the deduplication use case over a fake repository, covering successful merges, skipped recycled phones, non-merging name-only collisions, and transitive merges.