### PR TITLE
Wire nickname expansion into deduplication scorer

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCase.kt
@@ -7,6 +7,7 @@ import com.hereliesaz.cleanunderwear.match.MatchField
 import com.hereliesaz.cleanunderwear.match.MatchRecord
 import com.hereliesaz.cleanunderwear.match.ProbabilisticScorer
 import com.hereliesaz.cleanunderwear.match.StringSimilarity
+import com.hereliesaz.cleanunderwear.network.OnDeviceResearchAgent
 import com.hereliesaz.cleanunderwear.util.DiagnosticLogger
 import javax.inject.Inject
 
@@ -43,10 +44,20 @@ class DeduplicateTargetsUseCase(
      * ambiguous ones we must not blindly fuse. Exposed so it can be tuned (or driven from config)
      * as block characteristics evolve, and lowered in tests.
      */
-    private val maxPairwiseGroup: Int
+    private val maxPairwiseGroup: Int = DEFAULT_MAX_PAIRWISE_GROUP,
+    /**
+     * First-name → known-variant expansion handed to the [ProbabilisticScorer] so a shared
+     * (rare) phone or address can still fuse "Robert Smith" and "Bob Smith". Defaults to no
+     * expansion for tests; production supplies [OnDeviceResearchAgent.getNicknames] via the
+     * injected constructor below.
+     */
+    private val nicknames: (String) -> List<String> = { emptyList() }
 ) {
     @Inject
-    constructor(repository: TargetRepository) : this(repository, DEFAULT_MAX_PAIRWISE_GROUP)
+    constructor(
+        repository: TargetRepository,
+        researchAgent: OnDeviceResearchAgent
+    ) : this(repository, DEFAULT_MAX_PAIRWISE_GROUP, researchAgent::getNicknames)
 
     suspend operator fun invoke(onProgress: (Float, String) -> Unit = { _, _ -> }): Int {
         val groups = mutableMapOf<String, MutableList<Int>>() // identityKey -> list of IDs
@@ -81,6 +92,7 @@ class DeduplicateTargetsUseCase(
         }
 
         val scorer = ProbabilisticScorer(
+            nicknames = nicknames,
             frequency = { field, value ->
                 when (field) {
                     MatchField.PHONE -> phoneFreq[value] ?: 1

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCase.kt
@@ -57,7 +57,7 @@ class DeduplicateTargetsUseCase(
     constructor(
         repository: TargetRepository,
         researchAgent: OnDeviceResearchAgent
-    ) : this(repository, DEFAULT_MAX_PAIRWISE_GROUP, researchAgent::getNicknames)
+    ) : this(repository, nicknames = researchAgent::getNicknames)
 
     suspend operator fun invoke(onProgress: (Float, String) -> Unit = { _, _ -> }): Int {
         val groups = mutableMapOf<String, MutableList<Int>>() // identityKey -> list of IDs

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/domain/DeduplicateTargetsUseCaseTest.kt
@@ -135,6 +135,40 @@ class DeduplicateTargetsUseCaseTest {
     }
 
     @Test
+    fun recycledPhone_nicknameVariants_mergeOnlyWhenNicknamesWired() = runTest {
+        // A heavily recycled phone (shared by many rows) is frequency-penalised toward the floor,
+        // so the phone alone no longer forces a merge. Two rows that are the *same* person under
+        // nickname expansion — "Robert Smith" / "Bob Smith" — then hinge entirely on whether the
+        // scorer was handed a nickname map (production wires OnDeviceResearchAgent.getNicknames).
+        // The unnamed filler rows only exist to inflate the phone's corpus frequency; they carry
+        // no comparable name, so they never fuse with each other or with the Smiths.
+        val phone = "555-123-4567"
+        fun rows() = listOf(
+            Target(id = 1, displayName = "Robert Smith", phoneNumber = phone),
+            Target(id = 2, displayName = "Bob Smith", phoneNumber = phone)
+        ) + (1..62).map { Target(id = 100 + it, displayName = "Unnamed Entity", phoneNumber = phone) }
+
+        val nicknames: (String) -> List<String> = { name ->
+            when (name.lowercase()) {
+                "bob" -> listOf("robert")
+                "robert" -> listOf("bob")
+                else -> emptyList()
+            }
+        }
+
+        // Without nickname expansion the variant first names are not comparable, so the recycled
+        // phone is too weak on its own and the Smiths are left apart.
+        val withoutNicknames = FakeRepository(rows())
+        assertEquals(0, DeduplicateTargetsUseCase(withoutNicknames).invoke())
+        assertEquals(64, withoutNicknames.store.size)
+
+        // With nicknames wired, "Robert"/"Bob" agree on a full name and tip the pair over the bar.
+        val withNicknames = FakeRepository(rows())
+        assertEquals(1, DeduplicateTargetsUseCase(withNicknames, nicknames = nicknames).invoke())
+        assertEquals(63, withNicknames.store.size)
+    }
+
+    @Test
     fun threeWaySharedPhone_collapseTransitively() = runTest {
         val repo = FakeRepository(
             listOf(


### PR DESCRIPTION
## The incomplete task

The probabilistic entity-resolution work (recent commits `1d4119a`, `474066f`, `e0052b8`) left one wire unconnected.

`ProbabilisticScorer`'s `nicknames` parameter is documented as:

> Production wires `OnDeviceResearchAgent.getNicknames`.

…but `DeduplicateTargetsUseCase` constructed the scorer with **only** the `frequency` function, so `nicknames` fell back to its `{ emptyList() }` default. Nickname-aware first-name matching (e.g. Robert↔Bob) was therefore **dormant** in the live dedup pipeline — the scorer had the capability, a unit test for it, and the `OnDeviceResearchAgent.getNicknames` loader (reading `nicknames.json`), but nothing connected them.

## The fix

- Inject `OnDeviceResearchAgent` into `DeduplicateTargetsUseCase`'s `@Inject` constructor and pass `researchAgent::getNicknames` as the scorer's nickname source.
- The primary (test-facing) constructor keeps an empty-list default for `nicknames` and gains a default for `maxPairwiseGroup`, so existing call sites and tests are unchanged.

## Why it matters

A strong identifier (phone/email) on its own forces a MATCH, but the system deliberately **frequency-down-weights recycled values**. When a phone is recycled across many rows, agreement on it is penalised toward the floor — and then the nickname-aware name comparison is exactly what should tip two records that *are* the same person over the bar. Without the wiring, "Robert Smith" and "Bob Smith" sharing a recycled number were left unmerged (a false negative).

## Tests

Added `recycledPhone_nicknameVariants_mergeOnlyWhenNicknamesWired`, which runs the same fixture twice and asserts the outcome differs:
- **without** nicknames → 0 merges (the recycled phone alone is too weak),
- **with** nicknames → the two Smith rows collapse into one.

Full `DeduplicateTargetsUseCaseTest` suite (6 tests) passes locally via `./gradlew :app:testDebugUnitTest` (Android SDK 37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015M3AVVfm3f1pLkuRDEhShy)_