### PR TITLE
Make monitoring automatability honest + verify-before-merge enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Most people use "The Registry" to keep tabs on elderly relatives, estranged fami
 - **No Cloud Backend**: All surveillance data, contact details, and findings stay on *your* device.
 - **Autonomous Scything**: Background workers (the "Panopticon") perform routine scans of municipal rosters and obituary registries without manual intervention.
 - **Evidence-First Verification**: Every status change is backed by a "Verification Snippet"—the raw text found during the scan—allowing you to manually verify findings and correct false positives (e.g., surviving relatives mentioned in an obituary).
+- **Verify-before-merge enrichment**: When you resolve an UNVERIFIED contact via cyberbackgroundchecks, the result is only merged into the Registry if the candidate card is corroborated as the *same person* (a unique-identifier phone/email lookup, or a matching name). A conflicting card — e.g. a recycled phone number returning a stranger — is rejected, never written into your address book, and the reason is recorded as the contact's enrichment provenance.
 
 ---
 
@@ -27,10 +28,11 @@ Scythe through your digital ecosystems to build your Registry. Two surfaces:
 
 Apple iCloud has no first-party web surface that survives bot detection on Android, so Apple contacts remain in the passive bucket only.
 
-### 2. Autonomous Monitoring Engine
-- **The Daily Vigil**: Every morning at 9:00 AM, the app triggers a comprehensive scan of all active individuals in the Registry.
-- **Dynamic URL Discovery**: The `OnDeviceResearchAgent` automatically maps an individual's area code and location to relevant municipal arrest logs and funeral home registries.
-- **Stealth Scraping**: Uses a hybrid approach of `HtmlScraper` (fast) and `WebViewScraper` (stealth) to bypass modern bot-detection like Cloudflare and Turnstile.
+### 2. Monitoring Engine
+- **The Daily Vigil**: Every morning at 9:00 AM (battery-not-low + network constraints), the app runs the pipeline (dedupe → triage → scrape) over the Registry.
+- **Geographic source routing**: `SourceCatalog` maps a contact's ZIP/area code to county → state → multi-state records sources (`sources.json`), most-specific first.
+- **Honest automatability**: The vigil can *automatically* confirm a status change only for sources it can fetch and verify on its own (`HtmlScraper` for server-rendered pages, `WebViewScraper` for JS-rendered ones). Most public rosters and obituary aggregators bot-block non-browser requests or expose no name-queryable deep link, so they ship as **operator-launch-only** (`MANUAL_LANDING`) and are surfaced as in-app source chips you open in your own browser session. When a contact's locale has **no** automatable source, triage marks it `NO_AUTOMATED_SOURCE` and the profile says so plainly — the absence of an alert is never silently treated as "all clear." Adding a genuinely automatable source (a `QUERY_TEMPLATE`/`ROSTER_PAGE` entry, or a `multi_state_obituary` with a server-rendered result page) to `sources.json` turns its auto-path on with no code change.
+- **Stealth fetching**: `WebViewScraper` drives a hidden Android-UA WebView to render JS-heavy pages; `HtmlScraper` handles plain server-rendered HTML. Both run only against automatable (non-`MANUAL_LANDING`) sources.
 
 ### 3. Decentralized Persistence (Note Injection)
 The app uses your phone's native address book as its "external memory":
@@ -41,7 +43,7 @@ The app uses your phone's native address book as its "external memory":
 - **Status Badges**: Visual indicators for `Monitoring`, `Checking`, `Incarcerated`, `Deceased`, and `Archived`.
 - **Evidence Card**: View the exact match snippet found during a scan.
 - **Registry Actions**: Long-press any individual to Archive, Resume Monitoring, or view original verification sites.
-- **Identity Correlation (doxray)**: Each profile exposes launch-in-browser chips for the face-recognition, reverse-image-search, and name-based OSINT providers ported from the sister project [doxray](https://github.com/HereLiesAz/doxray) — PimEyes, FaceCheck.id, Lenso.ai, FaceSeek, Yandex Images, TinEye, Google Lens, CyberBackgroundChecks `/people/`, SmartBackgroundChecks `/people/`, GitHub user search, and `site:` Google searches for LinkedIn, Twitter/X, Instagram, and Facebook. These never auto-scrape (face services need a photo the Registry doesn't carry, and the name-based services bot-block raw HTTP); each chip opens the provider in the user's own browser so their session cookies apply. Defined in `app/src/main/assets/sources.json` under `identity_sources`; loaded by `SourceCatalog.identitySources()`.
+- **Identity Correlation (doxray)**: Each profile exposes launch-in-browser chips for the face-recognition, reverse-image-search, and name-based OSINT providers ported from the sister project [doxray](https://github.com/HereLiesAz/doxray) — PimEyes, FaceCheck.id, Lenso.ai, FaceSeek, Yandex Images, TinEye, Google Lens, CyberBackgroundChecks `/name/`, SmartBackgroundChecks `/name/`, GitHub user search, and `site:` Google searches for LinkedIn, Twitter/X, Instagram, and Facebook. These never auto-scrape (face services need a photo the Registry doesn't carry, and the name-based services bot-block raw HTTP); each chip opens the provider in the user's own browser so their session cookies apply. Defined in `app/src/main/assets/sources.json` under `identity_sources`; loaded by `SourceCatalog.identitySources()`.
 
 ---
 

--- a/app/src/main/assets/sources.json
+++ b/app/src/main/assets/sources.json
@@ -856,7 +856,7 @@
     }
   ],
 
-  "_identity_sources_comment": "Identity-correlation services (face recognition, reverse image search, name-based OSINT) ported from the sister project doxray (github.com/HereLiesAz/doxray). All entries ship as MANUAL_LANDING because (a) the face/image services require a photo upload the Registry never carries, and (b) the name-based services (PimEyes, FaceCheck.id, CyberBackgroundChecks/people, SmartBackgroundChecks, GitHub) bot-block raw HTTP requests — they must be exercised through the user's own browser session. Templates with {first}/{last} slots are filled at chip-render time via SourceUrlBuilder.",
+  "_identity_sources_comment": "Identity-correlation services (face recognition, reverse image search, name-based OSINT) ported from the sister project doxray (github.com/HereLiesAz/doxray). All entries ship as MANUAL_LANDING because (a) the face/image services require a photo upload the Registry never carries, and (b) the name-based services (PimEyes, FaceCheck.id, CyberBackgroundChecks, SmartBackgroundChecks, GitHub) bot-block raw HTTP requests — they must be exercised through the user's own browser session. The CyberBackgroundChecks / SmartBackgroundChecks chips use the same /name/{first}-{last} search path that the enrichment flow (util/CyberBackgroundChecks.kt) produces, so the chip and the auto-enricher land on the same page (previously the chip used a /people/ path that did not match). Templates with {first}/{last} slots are filled at chip-render time via SourceUrlBuilder.",
 
   "identity_sources": [
     {
@@ -919,7 +919,7 @@
       "id": "cyberbgc_people_lookup",
       "label": "CyberBackgroundChecks people lookup",
       "kind": "MANUAL_LANDING",
-      "url_template": "https://www.cyberbackgroundchecks.com/people/{first}-{last}",
+      "url_template": "https://www.cyberbackgroundchecks.com/name/{first}-{last}",
       "render": "WEBVIEW",
       "scope": "MULTI_STATE"
     },
@@ -927,7 +927,7 @@
       "id": "smartbgc_people_lookup",
       "label": "SmartBackgroundChecks people lookup",
       "kind": "MANUAL_LANDING",
-      "url_template": "https://www.smartbackgroundchecks.com/people/{first}-{last}",
+      "url_template": "https://www.smartbackgroundchecks.com/name/{first}-{last}",
       "render": "WEBVIEW",
       "scope": "MULTI_STATE"
     },

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/data/CleanUnderwearDatabase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/data/CleanUnderwearDatabase.kt
@@ -10,7 +10,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 /**
  * The physical manifestation of your localized surveillance state.
  */
-@Database(entities = [Target::class], version = 9, exportSchema = false)
+@Database(entities = [Target::class], version = 10, exportSchema = false)
 abstract class CleanUnderwearDatabase : RoomDatabase() {
     abstract fun targetDao(): TargetDao
 
@@ -164,6 +164,18 @@ abstract class CleanUnderwearDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds enrichment_provenance, the human-readable record of which CBC
+         * search mode(s) sourced a contact's data and whether the candidate
+         * identity was verified before merge. Nullable; existing rows backfill
+         * to NULL (no provenance recorded for pre-verification enrichments).
+         */
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE targets ADD COLUMN enrichment_provenance TEXT")
+            }
+        }
+
         fun getDatabase(context: Context): CleanUnderwearDatabase {
             return Instance ?: synchronized(this) {
                 Room.databaseBuilder(
@@ -173,7 +185,8 @@ abstract class CleanUnderwearDatabase : RoomDatabase() {
                 )
                 .addMigrations(
                     MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
-                    MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9
+                    MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
+                    MIGRATION_9_10
                 )
                 .build()
                 .also { Instance = it }

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/data/Target.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/data/Target.kt
@@ -39,7 +39,15 @@ data class Target(
     @ColumnInfo(name = "email")
     val email: String? = null,
     @ColumnInfo(name = "monitorability_state")
-    val monitorabilityState: MonitorabilityState = MonitorabilityState.READY
+    val monitorabilityState: MonitorabilityState = MonitorabilityState.READY,
+    /**
+     * Human-readable provenance for the last enrichment merge: which search
+     * mode(s) sourced the data and whether the candidate identity was verified
+     * against this contact. Lets the operator see *why* a value was written and
+     * reverse a bad merge. Null until the contact is enriched.
+     */
+    @ColumnInfo(name = "enrichment_provenance")
+    val enrichmentProvenance: String? = null
 )
 
 enum class TargetStatus {
@@ -120,10 +128,18 @@ data class TargetSourceInfo(
  *  READY               — has a usable name + at least one of phone or location/area code
  *  NEEDS_ENRICHMENT    — missing critical fields; queued for cyberbackgroundchecks lookup
  *  ENRICHMENT_FAILED   — cybg lookup returned nothing usable; will retry on a slower cadence
+ *  NO_AUTOMATED_SOURCE — has enough identity to scrape, but the contact's locale
+ *                        resolves to zero *automatable* sources (everything in the
+ *                        catalog for that area is operator-launch-only / MANUAL_LANDING).
+ *                        The daily vigil cannot confirm a status change for this contact;
+ *                        it must be checked manually via the in-app source chips. Surfaced
+ *                        instead of silently logging "no automated source" so the operator
+ *                        knows the vigil is not covering this person.
  */
 enum class MonitorabilityState {
     READY,
     NEEDS_ENRICHMENT,
-    ENRICHMENT_FAILED
+    ENRICHMENT_FAILED,
+    NO_AUTOMATED_SOURCE
 }
 

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/ScrapeTargetsUseCase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/ScrapeTargetsUseCase.kt
@@ -113,6 +113,26 @@ class ScrapeTargetsUseCase @Inject constructor(
                 .obituarySourcesFor(target.areaCode, target.residenceInfo)
                 .filter { it.kind != SourceKind.MANUAL_LANDING }
 
+            // Honesty gate (defensive — Triage already routes contacts with no
+            // automatable source to NO_AUTOMATED_SOURCE before they reach the
+            // READY scrape pool). If one slips through, flag it visibly instead
+            // of silently persisting an unchanged MONITORING status that looks
+            // like "checked, nothing found". The operator can then run the
+            // in-app source chips manually. Triage re-evaluates each pipeline
+            // run, so the contact returns to READY if the catalog later gains an
+            // automatable source for its area.
+            if (lockupSources.isEmpty() && obituarySources.isEmpty()) {
+                emitStep("no automated source for area ${target.areaCode ?: "?"} — manual check required")
+                repository.updateTarget(
+                    target.copy(
+                        monitorabilityState = MonitorabilityState.NO_AUTOMATED_SOURCE,
+                        lastScrapedTimestamp = now,
+                        nextScheduledCheck = now + (target.checkFrequencyHours * 3600000L)
+                    )
+                )
+                return
+            }
+
             var newStatus = TargetStatus.MONITORING
             var discoveredLockupUrl: String? = null
             var discoveredObitUrl: String? = null

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/TriageTargetsUseCase.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/domain/TriageTargetsUseCase.kt
@@ -5,6 +5,7 @@ import com.hereliesaz.cleanunderwear.data.TargetRepository
 import com.hereliesaz.cleanunderwear.data.TargetStatus
 import com.hereliesaz.cleanunderwear.data.TargetWorkInfo
 import com.hereliesaz.cleanunderwear.network.NameValidator
+import com.hereliesaz.cleanunderwear.network.SourceCatalog
 import com.hereliesaz.cleanunderwear.util.DiagnosticLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -21,7 +22,8 @@ import javax.inject.Inject
  * Parallelized to handle large registries (8000+ contacts) efficiently.
  */
 class TriageTargetsUseCase @Inject constructor(
-    private val repository: TargetRepository
+    private val repository: TargetRepository,
+    private val sourceCatalog: SourceCatalog
 ) {
     data class TriageResult(val ready: Int, val needsEnrichment: Int, val ignored: Int)
 
@@ -34,6 +36,7 @@ class TriageTargetsUseCase @Inject constructor(
         var readyCount = 0
         var needsEnrichmentCount = 0
         var ignoredCount = 0
+        var noAutomatedSourceCount = 0
 
         var offset = 0
         val chunkSize = 1000
@@ -60,6 +63,7 @@ class TriageTargetsUseCase @Inject constructor(
             val toReady = mutableListOf<Int>()
             val toNeedsEnrichment = mutableListOf<Int>()
             val toEnrichmentFailed = mutableListOf<Int>()
+            val toNoAutomatedSource = mutableListOf<Int>()
             val statusUpdates = mutableListOf<Pair<Int, TargetStatus>>()
 
             decisions.forEach { (id, decision) ->
@@ -73,12 +77,17 @@ class TriageTargetsUseCase @Inject constructor(
                             MonitorabilityState.READY -> toReady.add(id)
                             MonitorabilityState.NEEDS_ENRICHMENT -> toNeedsEnrichment.add(id)
                             MonitorabilityState.ENRICHMENT_FAILED -> toEnrichmentFailed.add(id)
+                            MonitorabilityState.NO_AUTOMATED_SOURCE -> toNoAutomatedSource.add(id)
                         }
                     }
                     if (decision.newStatus != null && decision.newStatus != original.status) {
                         statusUpdates.add(id to decision.newStatus)
                     }
-                    if (decision.state == MonitorabilityState.READY) readyCount++ else needsEnrichmentCount++
+                    when (decision.state) {
+                        MonitorabilityState.READY -> readyCount++
+                        MonitorabilityState.NO_AUTOMATED_SOURCE -> noAutomatedSourceCount++
+                        else -> needsEnrichmentCount++
+                    }
                 }
             }
 
@@ -91,6 +100,9 @@ class TriageTargetsUseCase @Inject constructor(
             if (toEnrichmentFailed.isNotEmpty()) {
                 repository.updateMonitorabilityStateBatch(toEnrichmentFailed, MonitorabilityState.ENRICHMENT_FAILED)
             }
+            if (toNoAutomatedSource.isNotEmpty()) {
+                repository.updateMonitorabilityStateBatch(toNoAutomatedSource, MonitorabilityState.NO_AUTOMATED_SOURCE)
+            }
             if (statusUpdates.isNotEmpty()) {
                 val now = System.currentTimeMillis()
                 statusUpdates.forEach { (id, status) ->
@@ -101,7 +113,10 @@ class TriageTargetsUseCase @Inject constructor(
             offset += chunkSize
         }
 
-        DiagnosticLogger.log("Triage (Chunked): $readyCount ready, $needsEnrichmentCount need enrichment, $ignoredCount archived")
+        DiagnosticLogger.log(
+            "Triage (Chunked): $readyCount ready, $needsEnrichmentCount need enrichment, " +
+                "$noAutomatedSourceCount no automated source, $ignoredCount archived"
+        )
         onProgress(1f, "Triage complete.")
         TriageResult(readyCount, needsEnrichmentCount, ignoredCount)
     }
@@ -114,10 +129,25 @@ class TriageTargetsUseCase @Inject constructor(
 
         return when {
             nameVerifiable && (hasPhone || hasLocation) -> {
+                // The contact is identifiable. But "READY" must mean the daily
+                // vigil can actually fetch + verify a source on its own — so
+                // gate on whether the locale resolves to an automatable
+                // (non-MANUAL_LANDING) source. If it doesn't, mark
+                // NO_AUTOMATED_SOURCE so getReadyDueTargets skips it (no silent
+                // churn) and the UI can flag it for a manual chip check.
                 val statusReset = if (target.status == TargetStatus.UNVERIFIED) {
                     TargetStatus.MONITORING
                 } else null
-                Decision(MonitorabilityState.READY, statusReset)
+                val automatable = sourceCatalog.hasAutomatableSourceFor(
+                    target.areaCode,
+                    target.residenceInfo
+                )
+                val state = if (automatable) {
+                    MonitorabilityState.READY
+                } else {
+                    MonitorabilityState.NO_AUTOMATED_SOURCE
+                }
+                Decision(state, statusReset)
             }
             !nameVerifiable -> {
                 val nextState = if (target.monitorabilityState == MonitorabilityState.ENRICHMENT_FAILED) {

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricher.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricher.kt
@@ -146,14 +146,98 @@ class CyberBackgroundChecksEnricher @Inject constructor() {
      * only fills gaps, it doesn't trample user-edited data.
      */
     fun mergeAll(target: Target, results: List<Pair<BrowserMission, Findings>>): Target {
-        fun priorityOf(m: BrowserMission): Int = when (m) {
-            is BrowserMission.CbcByPhone -> 4
-            is BrowserMission.CbcByEmail -> 3
-            is BrowserMission.CbcByAddress -> 2
-            is BrowserMission.CbcByName -> 1
-            else -> 0
+        val consensus = consensusFindings(results)
+
+        val nameWasPlaceholder = isPlaceholderName(target.displayName)
+
+        val merged = target.copy(
+            displayName = if (nameWasPlaceholder && consensus.name != null) consensus.name else target.displayName,
+            phoneNumber = target.phoneNumber ?: consensus.phone,
+            residenceInfo = target.residenceInfo ?: consensus.address,
+            areaCode = target.areaCode ?: consensus.phone?.filter { it.isDigit() }?.takeLast(10)?.take(3),
+        )
+        DiagnosticLogger.log("CYBG mergeAll: ${target.displayName} → ${merged.displayName} (${results.size} sources)")
+        return merged
+    }
+
+    /**
+     * Verify-before-merge. Like [mergeAll], but only adopts findings into the
+     * target when the candidate result is corroborated as the *same person*,
+     * and records why (or why not) in [Target.enrichmentProvenance].
+     *
+     * Verification basis:
+     *  - **Unique-identifier lookups win.** A card returned for an exact phone
+     *    or email is very likely the right person, so it verifies — UNLESS the
+     *    card also carries a name that conflicts with the contact's existing
+     *    real name (a recycled phone number returning a stranger), in which case
+     *    it is rejected.
+     *  - **Name consistency.** When the contact already has a real name, a
+     *    candidate whose name shares the same last name + first name (or first
+     *    initial) verifies.
+     *  - **Placeholder contacts** (no real name yet) are only ever resolved by a
+     *    unique-identifier lookup; a bare name/address search on a placeholder
+     *    is too weak to assign an identity, so it is not adopted.
+     *
+     * Unverified results are NOT written into the registry or system contacts —
+     * the caller should leave the contact UNVERIFIED and surface the provenance.
+     */
+    fun enrich(target: Target, results: List<Pair<BrowserMission, Findings>>): EnrichmentOutcome {
+        if (results.isEmpty()) {
+            val prov = "no results parsed"
+            return EnrichmentOutcome(target.copy(enrichmentProvenance = prov), verified = false, provenance = prov)
         }
 
+        val consensus = consensusFindings(results)
+        val modes = results.map { modeLabel(it.first) }.distinct().joinToString("+")
+        val (verified, basis) = verifySamePerson(target, results, consensus)
+
+        return if (verified) {
+            val nameWasPlaceholder = isPlaceholderName(target.displayName)
+            val prov = "$modes · verified ($basis)"
+            val merged = target.copy(
+                displayName = if (nameWasPlaceholder && consensus.name != null) consensus.name else target.displayName,
+                phoneNumber = target.phoneNumber ?: consensus.phone,
+                residenceInfo = target.residenceInfo ?: consensus.address,
+                areaCode = target.areaCode ?: consensus.phone?.filter { it.isDigit() }?.takeLast(10)?.take(3),
+                enrichmentProvenance = prov
+            )
+            DiagnosticLogger.log("CYBG enrich(verified): ${target.displayName} → ${merged.displayName} [$prov]")
+            EnrichmentOutcome(merged, verified = true, provenance = prov)
+        } else {
+            val prov = "$modes · NOT merged ($basis)"
+            DiagnosticLogger.log("CYBG enrich(rejected): ${target.displayName} [$prov]")
+            EnrichmentOutcome(target.copy(enrichmentProvenance = prov), verified = false, provenance = prov)
+        }
+    }
+
+    /** Result of [enrich]: the (possibly unchanged) target, whether the candidate
+     *  was verified as the same person, and a human-readable provenance string. */
+    data class EnrichmentOutcome(
+        val target: Target,
+        val verified: Boolean,
+        val provenance: String
+    )
+
+    private fun priorityOf(m: BrowserMission): Int = when (m) {
+        is BrowserMission.CbcByPhone -> 4
+        is BrowserMission.CbcByEmail -> 3
+        is BrowserMission.CbcByAddress -> 2
+        is BrowserMission.CbcByName -> 1
+        else -> 0
+    }
+
+    private fun modeLabel(m: BrowserMission): String = when (m) {
+        is BrowserMission.CbcByPhone -> "phone"
+        is BrowserMission.CbcByEmail -> "email"
+        is BrowserMission.CbcByAddress -> "address"
+        is BrowserMission.CbcByName -> "name"
+        else -> "other"
+    }
+
+    /** Consensus across results: the value seen most often wins; ties break on
+     *  source priority (phone > email > address > name). Shared by [mergeAll]
+     *  and [enrich]. */
+    private fun consensusFindings(results: List<Pair<BrowserMission, Findings>>): Findings {
         fun <T : Any> consensus(extract: (Findings) -> T?): T? {
             val grouped = results.mapNotNull { (m, f) ->
                 extract(f)?.let { it to priorityOf(m) }
@@ -163,23 +247,68 @@ class CyberBackgroundChecksEnricher @Inject constructor() {
                     .thenBy { it.value.max() }
             )?.key
         }
-
-        val name = consensus { it.name }
-        val address = consensus { it.address }
-        val phone = consensus { it.phone }
-
-        val nameWasPlaceholder = target.displayName.isBlank() ||
-            target.displayName == "Unnamed Entity" ||
-            target.displayName.startsWith("Unnamed Entity (")
-
-        val merged = target.copy(
-            displayName = if (nameWasPlaceholder && name != null) name else target.displayName,
-            phoneNumber = target.phoneNumber ?: phone,
-            residenceInfo = target.residenceInfo ?: address,
-            areaCode = target.areaCode ?: phone?.filter { it.isDigit() }?.takeLast(10)?.take(3),
+        return Findings(
+            name = consensus { it.name },
+            address = consensus { it.address },
+            phone = consensus { it.phone }
         )
-        DiagnosticLogger.log("CYBG mergeAll: ${target.displayName} → ${merged.displayName} (${results.size} sources)")
-        return merged
+    }
+
+    private fun isPlaceholderName(name: String): Boolean =
+        name.isBlank() || name == "Unnamed Entity" || name.startsWith("Unnamed Entity (")
+
+    /**
+     * Decides whether [results] describe the same person as [target]. Returns
+     * (verified, basis-for-logging). Pure Kotlin — reuses [NameValidator] from
+     * the same package, no Android dependency, so it stays unit-testable.
+     */
+    private fun verifySamePerson(
+        target: Target,
+        results: List<Pair<BrowserMission, Findings>>,
+        consensus: Findings
+    ): Pair<Boolean, String> {
+        val keyedByUniqueId = results.any {
+            it.first is BrowserMission.CbcByPhone || it.first is BrowserMission.CbcByEmail
+        }
+        val candidateNames = (results.mapNotNull { it.second.name } + listOfNotNull(consensus.name)).distinct()
+        val targetHasRealName = NameValidator.isVerifiable(target.displayName)
+
+        if (targetHasRealName) {
+            val targetTokens = NameValidator.tokenize(target.displayName)
+            val consistent = candidateNames.filter { nameConsistent(targetTokens, it) }
+            val conflicting = candidateNames.filter { !nameConsistent(targetTokens, it) }
+            return when {
+                consistent.isNotEmpty() -> true to "name match: ${consistent.first()}"
+                candidateNames.isEmpty() && keyedByUniqueId ->
+                    true to "phone/email lookup, card carried no conflicting name"
+                conflicting.isNotEmpty() ->
+                    false to "name conflict: card '${conflicting.first()}' ≠ ${target.displayName}"
+                else -> false to "uncorroborated"
+            }
+        }
+
+        // Placeholder / unnamed contact: only a unique-identifier lookup can
+        // safely assign an identity. A bare name/address card is too weak.
+        return if (keyedByUniqueId) {
+            true to "phone/email lookup resolved placeholder identity"
+        } else {
+            false to "placeholder contact, no unique-identifier lookup to corroborate"
+        }
+    }
+
+    /** Two names are consistent if they share the same last name and the same
+     *  first name (or first initial), case-insensitively. */
+    private fun nameConsistent(targetTokens: List<String>, candidate: String): Boolean {
+        val cand = NameValidator.tokenize(candidate)
+        if (targetTokens.size < 2 || cand.size < 2) return false
+        val tFirst = targetTokens.first().lowercase()
+        val tLast = targetTokens.last().lowercase()
+        val cFirst = cand.first().lowercase()
+        val cLast = cand.last().lowercase()
+        val lastMatch = tLast == cLast
+        val firstMatch = tFirst == cFirst ||
+            (tFirst.firstOrNull() != null && tFirst.firstOrNull() == cFirst.firstOrNull())
+        return lastMatch && firstMatch
     }
 
     /**

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricher.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricher.kt
@@ -296,8 +296,16 @@ class CyberBackgroundChecksEnricher @Inject constructor() {
         }
     }
 
-    /** Two names are consistent if they share the same last name and the same
-     *  first name (or first initial), case-insensitively. */
+    /**
+     * Two names are consistent if they share the same last name and a
+     * compatible first name, case-insensitively. First names match when they
+     * are equal, when one is a prefix of the other ("Jon" / "Jonathan"), or
+     * when one side is a single-letter initial sharing that letter ("J" / "John").
+     *
+     * Deliberately NOT a bare first-initial match: "James Smith" and
+     * "John Smith" share the initial 'J' and the surname but are different
+     * people, and merging them would defeat the whole point of verify-before-merge.
+     */
     private fun nameConsistent(targetTokens: List<String>, candidate: String): Boolean {
         val cand = NameValidator.tokenize(candidate)
         if (targetTokens.size < 2 || cand.size < 2) return false
@@ -307,7 +315,9 @@ class CyberBackgroundChecksEnricher @Inject constructor() {
         val cLast = cand.last().lowercase()
         val lastMatch = tLast == cLast
         val firstMatch = tFirst == cFirst ||
-            (tFirst.firstOrNull() != null && tFirst.firstOrNull() == cFirst.firstOrNull())
+            tFirst.startsWith(cFirst) ||
+            cFirst.startsWith(tFirst) ||
+            ((tFirst.length == 1 || cFirst.length == 1) && tFirst.firstOrNull() == cFirst.firstOrNull())
         return lastMatch && firstMatch
     }
 

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/SourceCatalog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/SourceCatalog.kt
@@ -108,6 +108,7 @@ class SourceCatalog @Inject constructor(
         val counties: Map<String, CountyEntry>? = null,
         val states: Map<String, StateEntry>? = null,
         val multi_state: List<RawSource>? = null,
+        val multi_state_obituary: List<RawSource>? = null,
         val identity_sources: List<RawSource>? = null
     )
 
@@ -167,10 +168,14 @@ class SourceCatalog @Inject constructor(
         }
 
         // multi_state list applies to lockup by default; obituary multi-state
-        // is currently empty (no widely useful national obit aggregator that
-        // takes per-name queries safely).
+        // is now wired from the `multi_state_obituary` JSON block. It ships
+        // empty until a per-name obituary source with a deep-linkable,
+        // server-rendered (non-captcha) result page is curated — adding one
+        // there is all it takes to turn the DECEASED auto-path on, with no
+        // code change. Operator-launch-only obit sources stay MANUAL_LANDING
+        // and are filtered out of the auto scrape (see ScrapeTargetsUseCase).
         multiStateLockup = parsed.multi_state.orEmpty().mapNotNull { it.toSource() }
-        multiStateObituary = emptyList()
+        multiStateObituary = parsed.multi_state_obituary.orEmpty().mapNotNull { it.toSource() }
 
         // identity_sources are country-agnostic identity-correlation services
         // (face recognition, reverse image search, name-based OSINT) ported
@@ -222,6 +227,21 @@ class SourceCatalog @Inject constructor(
 
     fun obituarySourcesFor(areaCode: String?, residenceInfo: String? = null): List<Source> =
         sourcesForLocale(resolveLocale(areaCode, residenceInfo), SourceCategory.OBITUARY)
+
+    /**
+     * True if the contact's locale resolves to at least one source the daily
+     * vigil can actually fetch + verify on its own — i.e. a lockup or obituary
+     * source whose kind is not [SourceKind.MANUAL_LANDING]. When this is false,
+     * the contact can only be checked by the operator via the in-app source
+     * chips; the auto scrape marks it
+     * [com.hereliesaz.cleanunderwear.data.MonitorabilityState.NO_AUTOMATED_SOURCE]
+     * rather than silently reporting "no change".
+     */
+    fun hasAutomatableSourceFor(areaCode: String?, residenceInfo: String? = null): Boolean {
+        val automatable = { s: Source -> s.kind != SourceKind.MANUAL_LANDING }
+        return lockupSourcesFor(areaCode, residenceInfo).any(automatable) ||
+            obituarySourcesFor(areaCode, residenceInfo).any(automatable)
+    }
 
     /**
      * Returns the country-agnostic identity-correlation sources (face

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/ui/MainViewModel.kt
@@ -453,18 +453,27 @@ class MainViewModel @Inject constructor(
                         return@runExclusive
                     }
 
-                    if (collected.isEmpty()) {
-                        repository.updateMonitorabilityState(
-                            target.id,
-                            com.hereliesaz.cleanunderwear.data.MonitorabilityState.ENRICHMENT_FAILED
+                    // Verify-before-merge: only promote the contact when the CBC
+                    // card is corroborated as the *same person*. An unverified or
+                    // conflicting card (e.g. a recycled phone number returning a
+                    // stranger) is NOT written into the registry or the user's
+                    // system contacts — we keep it UNVERIFIED and record why.
+                    val outcome = cbcEnricher.enrich(target, collected)
+                    if (outcome.verified) {
+                        repository.updateTarget(
+                            outcome.target.copy(
+                                status = TargetStatus.MONITORING,
+                                monitorabilityState =
+                                    com.hereliesaz.cleanunderwear.data.MonitorabilityState.READY
+                            )
                         )
                     } else {
-                        val merged = cbcEnricher.mergeAll(target, collected).copy(
-                            status = TargetStatus.MONITORING,
-                            monitorabilityState =
-                                com.hereliesaz.cleanunderwear.data.MonitorabilityState.READY
+                        repository.updateTarget(
+                            outcome.target.copy(
+                                monitorabilityState =
+                                    com.hereliesaz.cleanunderwear.data.MonitorabilityState.ENRICHMENT_FAILED
+                            )
                         )
-                        repository.updateTarget(merged)
                     }
                 }
 

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/ui/MainViewModel.kt
@@ -458,10 +458,10 @@ class MainViewModel @Inject constructor(
                     // conflicting card (e.g. a recycled phone number returning a
                     // stranger) is NOT written into the registry or the user's
                     // system contacts — we keep it UNVERIFIED and record why.
-                    val outcome = cbcEnricher.enrich(target, collected)
-                    if (outcome.verified) {
+                    val enrichment = cbcEnricher.enrich(target, collected)
+                    if (enrichment.verified) {
                         repository.updateTarget(
-                            outcome.target.copy(
+                            enrichment.target.copy(
                                 status = TargetStatus.MONITORING,
                                 monitorabilityState =
                                     com.hereliesaz.cleanunderwear.data.MonitorabilityState.READY
@@ -469,7 +469,7 @@ class MainViewModel @Inject constructor(
                         )
                     } else {
                         repository.updateTarget(
-                            outcome.target.copy(
+                            enrichment.target.copy(
                                 monitorabilityState =
                                     com.hereliesaz.cleanunderwear.data.MonitorabilityState.ENRICHMENT_FAILED
                             )

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/ui/TargetDetailScreen.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/ui/TargetDetailScreen.kt
@@ -179,6 +179,32 @@ fun TargetDetailScreen(
                 }
             }
 
+            // NO_AUTOMATED_SOURCE explainer. The contact is identifiable, but the
+            // daily vigil has no source it can fetch + verify on its own for this
+            // locale (everything in the catalog for the area is operator-launch
+            // only). Tell the user plainly and point them at the manual source
+            // chips below — don't let the absence of an alert read as "all clear".
+            if (target.monitorabilityState ==
+                com.hereliesaz.cleanunderwear.data.MonitorabilityState.NO_AUTOMATED_SOURCE
+            ) {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            text = "The daily vigil has no automated records source for this " +
+                                "contact's area — public records here are operator-launch only. " +
+                                "Use the Manual Research source chips below to check them in your " +
+                                "browser; the automatic scan cannot confirm a change for this person.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+
             HorizontalDivider()
 
             Text(
@@ -239,6 +265,17 @@ fun TargetDetailScreen(
                         )
                     }
                 }
+            }
+
+            // Enrichment provenance — shows which CBC search(es) sourced this
+            // contact's data and whether the candidate was verified as the same
+            // person, so a bad merge is visible and reversible.
+            target.enrichmentProvenance?.let { provenance ->
+                Text(
+                    text = "Enrichment: $provenance",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
 
             HorizontalDivider()

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricherTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricherTest.kt
@@ -328,6 +328,24 @@ class CyberBackgroundChecksEnricherTest {
     }
 
     @Test
+    fun enrich_sharedFirstInitialButDifferentName_isRejected() {
+        // "James Smith" must NOT merge into "John Smith" just because they share
+        // the surname and first initial 'J'.
+        val t = target(displayName = "John Smith")
+        val outcome = enricher.enrich(
+            t,
+            listOf(
+                BrowserMission.CbcByName("John Smith") to
+                    CyberBackgroundChecksEnricher.Findings(
+                        name = "James Smith", address = "5 Oak St", phone = null
+                    )
+            )
+        )
+        assertFalse(outcome.verified)
+        assertNull(outcome.target.residenceInfo)
+    }
+
+    @Test
     fun enrich_emptyResults_isRejectedWithProvenance() {
         val outcome = enricher.enrich(target(displayName = "Jane Roe"), emptyList())
         assertFalse(outcome.verified)

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricherTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/CyberBackgroundChecksEnricherTest.kt
@@ -4,6 +4,7 @@ import com.hereliesaz.cleanunderwear.data.Target
 import com.hereliesaz.cleanunderwear.domain.BrowserMission
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -232,5 +233,104 @@ class CyberBackgroundChecksEnricherTest {
         assertEquals("Unnamed Entity", merged.displayName)
         assertNull(merged.phoneNumber)
         assertNull(merged.residenceInfo)
+    }
+
+    // ---- enrich (verify-before-merge) ----
+
+    @Test
+    fun enrich_phoneLookupResolvesPlaceholderIdentity_isVerifiedAndAdoptsName() {
+        val t = target(displayName = "Unnamed Entity")
+        val outcome = enricher.enrich(
+            t,
+            listOf(
+                BrowserMission.CbcByPhone("5551234567") to
+                    CyberBackgroundChecksEnricher.Findings(
+                        name = "Jane Roe", address = "1 Main St", phone = null
+                    )
+            )
+        )
+        assertTrue(outcome.verified)
+        assertEquals("Jane Roe", outcome.target.displayName)
+        assertEquals("1 Main St", outcome.target.residenceInfo)
+        assertNotNull(outcome.target.enrichmentProvenance)
+    }
+
+    @Test
+    fun enrich_nameSearchConsistentWithRealName_isVerifiedAndFillsGaps() {
+        val t = target(displayName = "John Smith")
+        val outcome = enricher.enrich(
+            t,
+            listOf(
+                BrowserMission.CbcByName("John Smith") to
+                    CyberBackgroundChecksEnricher.Findings(
+                        name = "John Smith", address = "5 Oak St", phone = null
+                    )
+            )
+        )
+        assertTrue(outcome.verified)
+        assertEquals("John Smith", outcome.target.displayName)
+        assertEquals("5 Oak St", outcome.target.residenceInfo)
+    }
+
+    @Test
+    fun enrich_phoneCardNameConflictsWithRealName_isRejectedAndNotMerged() {
+        // Recycled phone number: the card belongs to a different person, so
+        // nothing must be written into the contact.
+        val t = target(displayName = "John Smith")
+        val outcome = enricher.enrich(
+            t,
+            listOf(
+                BrowserMission.CbcByPhone("5551234567") to
+                    CyberBackgroundChecksEnricher.Findings(
+                        name = "Bob Jones", address = "9 Elm Ave", phone = "5551234567"
+                    )
+            )
+        )
+        assertFalse(outcome.verified)
+        assertEquals("John Smith", outcome.target.displayName)
+        assertNull(outcome.target.residenceInfo)
+        assertTrue(outcome.provenance.contains("conflict"))
+    }
+
+    @Test
+    fun enrich_placeholderWithOnlyAddressCard_isRejected() {
+        val t = target(displayName = "Unnamed Entity")
+        val outcome = enricher.enrich(
+            t,
+            listOf(
+                BrowserMission.CbcByAddress("1 Main St") to
+                    CyberBackgroundChecksEnricher.Findings(
+                        name = "Stranger Person", address = "1 Main St", phone = "5550001111"
+                    )
+            )
+        )
+        assertFalse(outcome.verified)
+        assertEquals("Unnamed Entity", outcome.target.displayName)
+        assertNull(outcome.target.phoneNumber)
+    }
+
+    @Test
+    fun enrich_firstInitialMatchCountsAsConsistent() {
+        // "Jon Smith" vs "Jonathan Smith" — same last name, matching first
+        // initial (a common nickname/long-form variation).
+        val t = target(displayName = "Jon Smith")
+        val outcome = enricher.enrich(
+            t,
+            listOf(
+                BrowserMission.CbcByName("Jon Smith") to
+                    CyberBackgroundChecksEnricher.Findings(
+                        name = "Jonathan Smith", address = "5 Oak St", phone = null
+                    )
+            )
+        )
+        assertTrue(outcome.verified)
+        assertEquals("5 Oak St", outcome.target.residenceInfo)
+    }
+
+    @Test
+    fun enrich_emptyResults_isRejectedWithProvenance() {
+        val outcome = enricher.enrich(target(displayName = "Jane Roe"), emptyList())
+        assertFalse(outcome.verified)
+        assertEquals("no results parsed", outcome.provenance)
     }
 }

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/SourceCatalogAutomatabilityTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/SourceCatalogAutomatabilityTest.kt
@@ -1,0 +1,70 @@
+package com.hereliesaz.cleanunderwear.network
+
+import android.content.Context
+import android.content.res.AssetManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the automatability contract that drives [com.hereliesaz.cleanunderwear
+ * .data.MonitorabilityState.NO_AUTOMATED_SOURCE]. Reads the real sources.json.
+ *
+ * The shipped catalog currently has NO automatable (non-MANUAL_LANDING) lockup
+ * or obituary source — every gov roster the project surveyed either bot-blocks a
+ * non-browser fetch or has no deep-linkable, name-queryable result page, so they
+ * are all operator-launch-only. These tests pin that honest reality: the daily
+ * vigil cannot auto-confirm a status change today, and Triage routes such
+ * contacts to NO_AUTOMATED_SOURCE instead of silently reporting "no change".
+ *
+ * When a genuinely automatable source is later curated (a QUERY_TEMPLATE /
+ * ROSTER_PAGE entry, or a `multi_state_obituary` with a server-rendered result
+ * page), [hasNoAutomatableSource_forKnownMetro] will start failing — that is the
+ * intended signal to update this test and confirm the auto-path is wired on.
+ */
+class SourceCatalogAutomatabilityTest {
+
+    private fun loadCatalog(): SourceCatalog {
+        val stream = javaClass.getResourceAsStream("/sources.json")
+        assertNotNull("sources.json not on the test classpath", stream)
+        val bytes = stream!!.use { it.readBytes() }
+
+        val context = mockk<Context>()
+        val assets = mockk<AssetManager>()
+        every { context.assets } returns assets
+        every { assets.open("sources.json") } answers { bytes.inputStream() }
+        return SourceCatalog(context)
+    }
+
+    @Test
+    fun knownMetro_resolvesToSources_butNoneAreAutomatable() {
+        val catalog = loadCatalog()
+        // New Orleans (504) + an Orleans Parish ZIP resolves to lockup sources.
+        val lockup = catalog.lockupSourcesFor("504", "123 Magazine St, New Orleans, LA 70130")
+        assertTrue("expected catalog to resolve lockup sources for a known metro", lockup.isNotEmpty())
+
+        // ...but every one of them is operator-launch-only.
+        assertTrue(
+            "shipped catalog should have only MANUAL_LANDING lockup sources",
+            lockup.all { it.kind == SourceKind.MANUAL_LANDING }
+        )
+        assertFalse(
+            "no automatable source should exist for the shipped catalog (see class doc)",
+            catalog.hasAutomatableSourceFor("504", "123 Magazine St, New Orleans, LA 70130")
+        )
+    }
+
+    @Test
+    fun obituarySources_readFromMultiStateObituaryBlock() {
+        // The multi_state_obituary block is now wired (was hardcoded empty). It
+        // ships empty, so obituary lookups resolve to nothing until a source is
+        // curated. This guards the wiring: a malformed/renamed JSON key would
+        // make this throw or change behavior.
+        val catalog = loadCatalog()
+        val obit = catalog.obituarySourcesFor("504", "123 Magazine St, New Orleans, LA 70130")
+        assertTrue("obituary sources ship empty until a per-name source is curated", obit.isEmpty())
+    }
+}

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/SourceCatalogIdentityTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/SourceCatalogIdentityTest.kt
@@ -90,6 +90,29 @@ class SourceCatalogIdentityTest {
     }
 
     @Test
+    fun cbcIdentityChip_usesSameNameSearchPathAsEnricher() {
+        // Regression: the CBC / SmartBGC chips previously used a /people/ path
+        // that did not match the /name/ search path the enrichment flow
+        // (util.CyberBackgroundChecks) produces, so the manual chip and the
+        // auto-enricher landed on different pages. They must now agree.
+        val catalog = loadCatalog()
+        val cbc = catalog.identitySources().first { it.id == "cyberbgc_people_lookup" }
+        val chipUrl = SourceUrlBuilder.buildFetchUrl(cbc, "John", "Smith")
+        assertEquals("https://www.cyberbackgroundchecks.com/name/John-Smith", chipUrl)
+        // Same host + path structure the enricher produces (case-insensitive).
+        assertEquals(
+            com.hereliesaz.cleanunderwear.util.CyberBackgroundChecks.getNameSearchUrl("John Smith"),
+            chipUrl.lowercase()
+        )
+
+        val smart = catalog.identitySources().first { it.id == "smartbgc_people_lookup" }
+        assertEquals(
+            "https://www.smartbackgroundchecks.com/name/John-Smith",
+            SourceUrlBuilder.buildFetchUrl(smart, "John", "Smith")
+        )
+    }
+
+    @Test
     fun identitySources_areCatalogRecognized() {
         // isFromCatalog must accept every identity URL so the prefix-whitelist
         // used by ContactHarvester / UI doesn't reject identity-source links.


### PR DESCRIPTION
## Why

I analysed the userflow, the source-derivation logic, and the contact-enrichment workflow, then mock-ran each and live-tested the resulting URLs. The headline finding:

- **The "autonomous" daily vigil could never detect anything.** Every source in `sources.json` is `MANUAL_LANDING`, and `ScrapeTargetsUseCase` filters those out — so the scrape phase always no-ops while persisting an *unchanged* `MONITORING` status that reads as "checked, nothing found." Live tests confirmed why most sources ship `MANUAL_LANDING`: gov rosters and obituary aggregators bot-block non-browser fetches (503/403) or expose no name-queryable deep link.
- **Enrichment had two contradictory CyberBackgroundChecks URL schemes** (`util` used `/name//phone/`, the doxray chips used `/people/`), and it **merged result cards into the registry — and the user's real address book — with no same-person check**, so a recycled phone number could write a stranger's data onto a contact.

Rather than fabricate `QUERY_TEMPLATE` entries I couldn't validate (the exact "false confidence" the catalog comment warns against), this PR makes the automatable path **real and honest**, and hardens enrichment.

## What changed

- **Honest automatability.** Triage gates `READY` on `SourceCatalog.hasAutomatableSourceFor(...)`. A contact whose locale has no automatable (non-`MANUAL_LANDING`) source is marked `NO_AUTOMATED_SOURCE` (new `MonitorabilityState`) so the scrape pool skips it (no silent churn) and the profile says the vigil can't cover it. `ScrapeTargetsUseCase` keeps a defensive gate for the same case instead of silently reporting "no change."
- **Verify-before-merge.** New `CyberBackgroundChecksEnricher.enrich()` only adopts CBC findings when the candidate is corroborated as the *same person* (a unique-identifier phone/email lookup, or a matching name). Conflicting cards are rejected and never written back. The reason is recorded on the contact (`enrichment_provenance`, `MIGRATION_9_10`) and surfaced in `TargetDetailScreen`.
- **Unified CBC URL scheme.** The doxray CBC/SmartBGC chips now use the same `/name/{first}-{last}` search path the enrichment flow produces (was `/people/`).
- **Obituary auto-path wiring.** `multi_state_obituary` is now read from `sources.json` (was hardcoded empty), so a curated per-name obituary source with a server-rendered result page turns the `DECEASED` auto-path on with no code change.
- **README** updated to describe what the engine actually does.

## Tests
- `CyberBackgroundChecksEnricherTest`: new `enrich()` verification cases (verified-by-phone, name-consistency incl. first-initial, recycled-number rejection, placeholder-address rejection, empty results).
- `SourceCatalogIdentityTest`: pins the unified CBC/SmartBGC URL against the enricher's path.
- `SourceCatalogAutomatabilityTest` (new): regression guard documenting that the shipped catalog has zero automatable sources today and that `multi_state_obituary` is wired.

## Notes / caveats
- A full Android build isn't runnable in this environment (no SDK, empty Gradle cache); changes were verified by review + JSON validation. **Please run `./gradlew testDebugUnitTest` and a debug build before merging.** Room migration 9→10 (`ALTER TABLE targets ADD COLUMN enrichment_provenance TEXT`) follows the existing `MIGRATION_6_7` pattern.
- With the shipped catalog (all `MANUAL_LANDING`), every identifiable contact now triages to `NO_AUTOMATED_SOURCE` — this is the honest current state; adding one automatable source to `sources.json` flips those back to `READY`.
- The `/name/` CBC path assumes that is CBC's live search path (confirmed against opt-out guides; the site 403s raw HTTP so it couldn't be auto-validated). Worth a manual browser check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLM3y518hgoNGkNBFrbKSx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLM3y518hgoNGkNBFrbKSx)_