### PR TITLE
Make the app version adhere strictly to version.properties

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -45,10 +45,9 @@ jobs:
         id: gradle-build
         run: |
           set +e
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
 
-          # Build the APK
-          ./gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache > build.log 2>&1
+          # Build the APK (version comes from version.properties, not the build)
+          ./gradlew assembleDebug --build-cache > build.log 2>&1
 
           EXIT_CODE=$?
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
@@ -99,14 +98,14 @@ jobs:
         if: success() && github.event_name == 'push'
         id: release_vars
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-
-          # Extract version info from properties file
+          # version.properties is the single source of truth. VERSION_NAME
+          # mirrors the APK's internal versionName.versionCode (e.g. 1.0.5.16).
           MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ' || echo "1")
           MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ' || echo "0")
           PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ' || echo "0")
+          BUILD=$(grep 'versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ' || echo "1")
 
-          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
+          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD"
 
           TAG_NAME="latest-debug-v${MAJOR}.${MINOR}"
 

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -87,8 +87,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          ./gradlew assembleRelease -PversionBuild=$BUILD_NUMBER \
+          ./gradlew assembleRelease \
             -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
             -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
             -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
@@ -98,21 +97,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-
+          # version.properties is the single source of truth — no git-derived
+          # patch/build numbers. VERSION_NAME mirrors the APK's internal
+          # versionName.versionCode (e.g. 1.0.5.16).
           MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
           MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          BUILD=$(grep 'versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
 
-          # Calculate patch from commits since last minor bump
-          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
-          if [ -n "$MINOR_COMMIT" ]; then
-            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
-          else
-            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          fi
-
-          VERSION_NAME="${MAJOR}.${MINOR}.${PATCH}.${BUILD_NUMBER}"
+          VERSION_NAME="${MAJOR}.${MINOR}.${PATCH}.${BUILD}"
           TAG_NAME="latest-release-v${MAJOR}.${MINOR}"
+
+          # Dynamic app name from settings.gradle.kts
+          APP_NAME=$(grep 'rootProject.name' settings.gradle.kts | sed -E "s/.*=.*[\"'](.*)[\"']/\1/" || echo "App")
 
           # Locate built APK
           APK_ORIGINAL=$(find app/build/outputs/apk/release -name "*.apk" | head -n 1)
@@ -122,7 +119,7 @@ jobs:
             exit 1
           fi
 
-          TARGET_NAME="GraffitiXR-${VERSION_NAME}-release.apk"
+          TARGET_NAME="${APP_NAME}-${VERSION_NAME}-release.apk"
           mv "$APK_ORIGINAL" "$TARGET_NAME"
 
           git config user.name "github-actions[bot]"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,28 +15,16 @@ val versionProps = Properties().apply {
     }
 }
 
-var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
-var currentVersionPatch = versionProps.getProperty("versionPatch", "0").toInt()
-
-// Automatically increment version values for builds
-val isBuilding = gradle.startParameter.taskNames.any {
-    val task = it.lowercase()
-    task.contains("assemble") || task.contains("bundle") || task.contains("install")
-}
-
-if (isBuilding) {
-    currentVersionCode++
-    currentVersionPatch++
-    versionProps.setProperty("versionBuild", currentVersionCode.toString())
-    versionProps.setProperty("versionPatch", currentVersionPatch.toString())
-    versionPropsFile.outputStream().use {
-        versionProps.store(it, "Auto-incremented by build")
-    }
-}
-
+// version.properties is the single source of truth for the version. The build
+// reads it verbatim and never mutates it — bumping the version is a deliberate
+// edit to that file, not a side effect of compiling. (Previously the build
+// auto-incremented versionBuild/versionPatch and wrote them back, so the APK
+// version was always the file value + 1 and the committed file drifted on
+// every local build.)
 val verMajor = versionProps.getProperty("versionMajor", "1")
 val verMinor = versionProps.getProperty("versionMinor", "0")
 val verPatch = versionProps.getProperty("versionPatch", "0")
+val verBuild = versionProps.getProperty("versionBuild", "1").toInt()
 val currentVersionName = "$verMajor.$verMinor.$verPatch"
 
 kotlin {
@@ -62,7 +50,7 @@ android {
         applicationId = "com.hereliesaz.cleanunderwear"
         minSdk = 26
         targetSdk = 37
-        versionCode = currentVersionCode
+        versionCode = verBuild
         versionName = currentVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,10 +21,13 @@ val versionProps = Properties().apply {
 // auto-incremented versionBuild/versionPatch and wrote them back, so the APK
 // version was always the file value + 1 and the committed file drifted on
 // every local build.)
-val verMajor = versionProps.getProperty("versionMajor", "1")
-val verMinor = versionProps.getProperty("versionMinor", "0")
-val verPatch = versionProps.getProperty("versionPatch", "0")
-val verBuild = versionProps.getProperty("versionBuild", "1").toInt()
+// Properties.load() strips leading but not trailing whitespace, so trim each
+// value — a stray trailing space in a hand-edited file would otherwise crash
+// versionBuild.toInt() or produce a malformed versionName like "1.0.5 ".
+val verMajor = versionProps.getProperty("versionMajor", "1").trim()
+val verMinor = versionProps.getProperty("versionMinor", "0").trim()
+val verPatch = versionProps.getProperty("versionPatch", "0").trim()
+val verBuild = versionProps.getProperty("versionBuild", "1").trim().toInt()
 val currentVersionName = "$verMajor.$verMinor.$verPatch"
 
 kotlin {

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
-#Auto-incremented by build
-#Tue May 19 07:50:14 CDT 2026
+#Single source of truth for the app version. Maintained by hand; the build
+#reads these values verbatim and never rewrites this file. Bump deliberately.
 versionBuild=16
 versionMajor=1
 versionMinor=0


### PR DESCRIPTION
## What & why

The version the app reports must be the single source of truth declared in `version.properties`. It wasn't, in three compounding ways:

1. **`app/build.gradle.kts` mutated the file and diverged from it.** Every `assemble`/`bundle`/`install` build incremented `versionBuild` *and* `versionPatch`, **wrote them back** to `version.properties`, and used the *incremented* patch for `versionName`. So the APK was always the file value **+1**, and the committed file drifted on every local build (hence the `#Auto-incremented by build` header + stale timestamp).
2. **The CI override was dead code.** Both workflows passed `-PversionBuild=$BUILD_NUMBER`, but `build.gradle.kts` read `versionProps.getProperty("versionBuild")` from the *file*, never the Gradle project property — so the override was silently ignored.
3. **The release workflows computed the version a third way.** `release-apk.yml` derived `PATCH` from `git rev-list` commit counts; both workflows appended a git-count build number. The APK's internal version, the release artifact filename, and the git tag could all disagree.

## Changes

- **`app/build.gradle.kts`** — removed the auto-increment + file-rewrite block. The build now reads the four values verbatim: `versionCode = versionBuild`, `versionName = major.minor.patch`. Bumping the version is now a deliberate edit to `version.properties`.
- **`.github/workflows/release-apk.yml`** — dropped the dead `-PversionBuild`, removed the `git rev-list`/`git blame` patch computation, and now builds `VERSION_NAME=MAJOR.MINOR.PATCH.BUILD` straight from the file (matching the APK's internal `versionName.versionCode`). Also fixed the stale `GraffitiXR-` artifact name to derive the app name from `settings.gradle.kts`.
- **`.github/workflows/merged-build.yml`** — same alignment for the debug release; dropped `-PversionBuild` and the git-count suffix.
- **`version.properties`** — replaced the misleading `#Auto-incremented by build` header to reflect that it's now the hand-maintained source of truth.

## Result
With the shipped file (`1 / 0 / 5 / 16`): `versionName = 1.0.5`, `versionCode = 16`, artifacts named `…-1.0.5.16-….apk`, tag `latest-release-v1.0`. A CI build no longer dirties `version.properties` in git.

## Verification
No Android SDK in this environment, so CI is the gate. Statically verified: `build.gradle.kts` no longer calls `setProperty`/`outputStream` (file is never written); neither workflow passes `-PversionBuild` or uses `git rev-list`/`git blame` for the version.

## Flagged, out of scope
`jules-run.sh` / `jules-run2.sh` / `jules-run3.sh` replicate the old `git blame` patch calculation. They're release helper scripts, not the CI workflows, so per the agreed scope they're left untouched — but they'd reintroduce the divergent version string if they still drive any release and should be aligned later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLM3y518hgoNGkNBFrbKSx)_