### PR TITLE
Make BOP facility→state resolution format-robust

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/BopFacilityCatalog.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/BopFacilityCatalog.kt
@@ -1,33 +1,56 @@
 package com.hereliesaz.cleanunderwear.network
 
 /**
- * Maps a Federal Bureau of Prisons facility name (the BOP inmate-locator
- * `faclName` field, e.g. "USP ATLANTA", "FCI BUTNER") to the US state the
- * facility sits in.
+ * Resolves a Federal Bureau of Prisons facility to the US state it sits in, for
+ * the national BOP search's facility-state agreement gate (a same-name federal
+ * record is only surfaced when the facility's state matches the contact's).
  *
- * This exists to support the *facility-state agreement* gate on the national
- * BOP search: a same-name federal record is only surfaced for review when the
- * facility's state matches the contact's resolved state.
+ * Resolution is a fallback chain ([stateFor]) so it is robust to the *string
+ * format* the locator returns:
+ *   1. the stable facility **code** (`faclCode`, e.g. "ATL") — format-invariant;
+ *   2. a normalized **city/location keyword** in `faclName` (case-, punctuation-,
+ *      and word-order-independent, so "USP ATLANTA", "Atlanta USP", and
+ *      "U.S. Penitentiary, Atlanta, GA" all resolve);
+ *   3. an explicit, validated **trailing state token** ("…, GA").
  *
- * IMPORTANT CAVEATS — read before relying on this:
- *  - This is a **hand-maintained, best-effort** table. The BOP opens, closes,
- *    and renames institutions; new facilities will be absent until added here.
- *    When [stateFor] returns null the caller treats it as "cannot establish
- *    agreement" and does NOT surface the match (strict gate), so a gap here
- *    causes a *false negative* (a real incarceration is not flagged), not a
- *    false positive. Keep the table current to avoid silently missing matches.
- *  - Federal inmates are frequently held **out of their home state**, so even a
- *    correct lookup can legitimately disagree with the contact's state and
- *    suppress a true match. That tradeoff was chosen deliberately (strictest
- *    matching) — widen or remove the gate if it proves too aggressive.
- *
- * Matching is by city/location keyword: `faclName` is uppercased and scanned
- * for a known location token (longest token first so "TERRE HAUTE" wins over a
- * bare "HAUTE"). Keys are uppercase location names as they appear in faclName.
+ * IMPORTANT — what fallbacks can and cannot do:
+ *  - String-format variation is fully handled by the chain above.
+ *  - Geographic knowledge (that "Butner" is in NC) cannot be *derived* by any
+ *    parsing — it must live in the tables below. The BOP institution set is
+ *    finite, so [locationToState] aims to be complete; [codeToState] is a
+ *    high-confidence, verified-only seed (a *wrong* code/state is worse than a
+ *    missing one — a miss merely makes the strict gate suppress the match). New
+ *    or renamed facilities are the only residual gap; verify additions against
+ *    the official bop.gov facility list rather than guessing.
  */
 object BopFacilityCatalog {
 
-    /** Location keyword (uppercase) -> two-letter state code. */
+    /**
+     * Authoritative two-letter US state/territory codes, used to validate a
+     * trailing state token parsed out of a facility name (step 3). Mirrors the
+     * `states` keys in `app/src/main/assets/sources.json`; kept inline so this
+     * object stays pure (no Android context) and unit-testable.
+     */
+    private val usStateCodes: Set<String> = setOf(
+        "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI",
+        "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN",
+        "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
+        "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA",
+        "WV", "WI", "WY", "PR", "VI", "GU", "AS", "MP",
+    )
+
+    /**
+     * Stable BOP facility code → state. Format-invariant and the most reliable
+     * signal when present. Intentionally a small, high-confidence seed: codes
+     * here must be verified against bop.gov. Anything not listed simply falls
+     * through to name parsing, so a short table is safe (never wrong, only
+     * less complete).
+     */
+    private val codeToState: Map<String, String> = mapOf(
+        "ATL" to "GA", // USP Atlanta
+    )
+
+    /** City/location keyword (uppercase) → state. The primary resolver. */
     private val locationToState: Map<String, String> = mapOf(
         // Alabama
         "MONTGOMERY" to "AL", "TALLADEGA" to "AL", "ALICEVILLE" to "AL",
@@ -91,6 +114,8 @@ object BopFacilityCatalog {
         "LEWISBURG" to "PA", "CANAAN" to "PA", "WAYMART" to "PA",
         "MCKEAN" to "PA", "BRADFORD" to "PA", "SCHUYLKILL" to "PA",
         "MINERSVILLE" to "PA", "PHILADELPHIA" to "PA",
+        // Puerto Rico
+        "GUAYNABO" to "PR",
         // South Carolina
         "ESTILL" to "SC", "BENNETTSVILLE" to "SC", "EDGEFIELD" to "SC",
         "WILLIAMSBURG" to "SC",
@@ -117,13 +142,36 @@ object BopFacilityCatalog {
     // Longest keys first so multi-word locations win over substrings.
     private val keysByLength: List<String> = locationToState.keys.sortedByDescending { it.length }
 
+    /** Convenience overload for callers that only have the display name. */
+    fun stateFor(faclName: String?): String? = stateFor(faclCode = null, faclName = faclName)
+
     /**
-     * Best-effort state code (e.g. "GA") for a BOP facility name, or null if the
-     * facility isn't in the table. Null means the caller cannot establish
-     * facility-state agreement.
+     * Best-effort state code (e.g. "GA") for a BOP facility, or null when it
+     * can't be resolved (caller treats null as "cannot establish agreement").
      */
-    fun stateFor(faclName: String?): String? {
-        val s = faclName?.trim()?.uppercase()?.takeIf { it.isNotBlank() } ?: return null
-        return keysByLength.firstOrNull { s.contains(it) }?.let { locationToState[it] }
+    fun stateFor(faclCode: String?, faclName: String?): String? {
+        // 1. Stable facility code — format-invariant, most reliable.
+        faclCode?.trim()?.uppercase()?.takeIf { it.isNotBlank() }?.let { code ->
+            codeToState[code]?.let { return it }
+        }
+
+        // Normalize the display name: uppercase, every non-alphanumeric run to a
+        // single space, trimmed. Makes matching punctuation- and order-agnostic.
+        val norm = faclName
+            ?.uppercase()
+            ?.replace(Regex("[^A-Z0-9]+"), " ")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+
+        // 2. City/location keyword, matched on whole-word boundaries.
+        val padded = " $norm "
+        keysByLength.firstOrNull { padded.contains(" $it ") }
+            ?.let { return locationToState[it] }
+
+        // 3. Explicit trailing state token, validated against the real code set.
+        norm.substringAfterLast(' ').takeIf { it in usStateCodes }?.let { return it }
+
+        return null
     }
 }

--- a/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/IdentityVerifier.kt
+++ b/app/src/main/kotlin/com/hereliesaz/cleanunderwear/network/IdentityVerifier.kt
@@ -3,6 +3,7 @@ package com.hereliesaz.cleanunderwear.network
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.hereliesaz.cleanunderwear.util.DiagnosticLogger
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -144,11 +145,23 @@ class IdentityVerifier @Inject constructor() {
             // to a false positive here). NOTE: federal inmates are often held
             // out-of-state, so this can suppress genuine matches by design.
             val recFacl = stringField(record, "faclName")
-            val facilityState = BopFacilityCatalog.stateFor(recFacl)
+            val recFaclCode = stringField(record, "faclCode")
+            val facilityState = BopFacilityCatalog.stateFor(recFaclCode, recFacl)
             val contactState = corroboration.state?.trim()?.takeIf { it.isNotBlank() }
             if (facilityState == null || contactState == null ||
                 !facilityState.equals(contactState, ignoreCase = true)
             ) {
+                // Surface catalog gaps: a current, name+corroborator-matching
+                // record dropped *solely* because the facility's state couldn't
+                // be resolved is a match we would have shown if BopFacilityCatalog
+                // knew this facility. Log it so the gap is fixable, not silent.
+                if (facilityState == null && contactState != null) {
+                    DiagnosticLogger.log(
+                        "BOP: dropped corroborated '${name.first} ${name.last}' — unresolved " +
+                            "facility state (faclCode='$recFaclCode', faclName='$recFacl')",
+                        DiagnosticLogger.LogEntry.LogLevel.WARN
+                    )
+                }
                 continue
             }
 

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/BopFacilityCatalogTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/BopFacilityCatalogTest.kt
@@ -16,6 +16,7 @@ class BopFacilityCatalogTest {
     @Test
     fun stateFor_caseAndWhitespaceInsensitive() {
         assertEquals("GA", BopFacilityCatalog.stateFor("  usp atlanta  "))
+        assertEquals("NC", BopFacilityCatalog.stateFor("  fci   butner  "))
     }
 
     @Test
@@ -26,9 +27,42 @@ class BopFacilityCatalogTest {
     }
 
     @Test
+    fun stateFor_wordOrderIndependent() {
+        // Whatever order the API emits the name in, the city keyword resolves.
+        assertEquals("GA", BopFacilityCatalog.stateFor("Atlanta USP"))
+    }
+
+    @Test
+    fun stateFor_punctuationIndependent() {
+        assertEquals("NC", BopFacilityCatalog.stateFor("FCI-BUTNER"))
+        assertEquals("GA", BopFacilityCatalog.stateFor("U.S. Penitentiary, Atlanta, GA"))
+    }
+
+    @Test
+    fun stateFor_facilityCode_isMostStable() {
+        // Code wins and is format-invariant, even with a garbage display name.
+        assertEquals("GA", BopFacilityCatalog.stateFor(faclCode = "atl", faclName = "???"))
+        // Unknown code falls through to name parsing.
+        assertEquals("NC", BopFacilityCatalog.stateFor(faclCode = "XYZ", faclName = "FCI BUTNER"))
+    }
+
+    @Test
+    fun stateFor_trailingStateToken_resolvesUnknownCity() {
+        // City not in the table, but an explicit, valid trailing state code is.
+        assertEquals("NC", BopFacilityCatalog.stateFor("FCI SOMEPLACE, NC"))
+    }
+
+    @Test
+    fun stateFor_nonTrailingTwoLetterRun_doesNotFalseTrigger() {
+        // "OR" appears mid-name but is not the trailing token → no false match.
+        assertNull(BopFacilityCatalog.stateFor("CAMP OR FARM"))
+    }
+
+    @Test
     fun stateFor_unknownOrBlank_returnsNull() {
         assertNull(BopFacilityCatalog.stateFor("FCI NOWHERELAND"))
         assertNull(BopFacilityCatalog.stateFor(""))
         assertNull(BopFacilityCatalog.stateFor(null))
+        assertNull(BopFacilityCatalog.stateFor(faclCode = "", faclName = null))
     }
 }

--- a/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/IdentityVerifierTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/cleanunderwear/network/IdentityVerifierTest.kt
@@ -119,12 +119,13 @@ class IdentityVerifierTest {
         last: String,
         actRel: String = "",
         facl: String = "USP ATLANTA",
+        faclCode: String = "",
         projRel: String = "01/01/2030",
         mid: String = "A",
         age: String = "45",
         inmateNum: String = "12345-678",
     ) = """{"nameLast":"$last","nameFirst":"$first","nameMiddle":"$mid","sex":"Male",""" +
-        """"age":"$age","inmateNum":"$inmateNum","faclName":"$facl",""" +
+        """"age":"$age","inmateNum":"$inmateNum","faclName":"$facl","faclCode":"$faclCode",""" +
         """"projRelDate":"$projRel","actRelDate":"$actRel"}"""
 
     /**
@@ -319,6 +320,15 @@ class IdentityVerifierTest {
         val json = bopJson(inmate(first = "JOHN", last = "SMITH"))
         val result = verifier.verifyBopInmateJson(json, "John Smith", corro(state = "CA"))
         assertFalse(result.isMatch)
+    }
+
+    @Test
+    fun bop_resolvesViaFacilityCode_whenNameUnparseable() {
+        // A stable faclCode resolves the facility state even when faclName is
+        // garbage — the format-robust path.
+        val json = bopJson(inmate(first = "JOHN", last = "SMITH", facl = "???", faclCode = "ATL"))
+        val result = verifier.verifyBopInmateJson(json, "John Smith", corro(state = "GA"))
+        assertTrue(result.isMatch)
     }
 
     @Test


### PR DESCRIPTION
## Why

Follow-up to #63. The strictest federal-BOP gate only surfaces a match when the facility's state equals the contact's state, via `BopFacilityCatalog.stateFor(faclName)`. That relied on a single city-keyword substring lookup against the free-text `faclName`, which I had caveated as fragile to string-format variation. That caveat is fixable — this PR replaces it with a robust fallback chain.

The honest distinction: **string-format variation** is fully solvable with fallbacks (done here); **geographic knowledge** (that "Butner" is in NC) can't be *derived* by parsing and must live in a lookup table — but the BOP institution set is finite, so the table can be made effectively complete.

## What

`BopFacilityCatalog.stateFor` is now an ordered chain, robust to whatever shape the locator returns:

1. **Stable facility code** (`faclCode`, e.g. `ATL`) — format-invariant, most reliable. `IdentityVerifier.verifyBopInmateJson` now reads `faclCode` (the `output=json` response already includes it — **no URL change**) and passes it to a new `stateFor(faclCode, faclName)` overload. Absent code ⇒ degrades to name parsing (no regression).
2. **Normalized city/location keyword** — uppercase, punctuation→space, collapsed whitespace, matched on whole-word boundaries. So `"Atlanta USP"`, `"FCI-BUTNER"`, and `"U.S. Penitentiary, Atlanta, GA"` all resolve.
3. **Explicit trailing state token** (`"…, NC"`), validated against the real US state/territory code set.

### Honest residuals (unchanged by design)
- The **code map is a high-confidence, verified-only seed** — a *wrong* entry is worse than a missing one (a miss just makes the strict gate suppress). The **city map is the primary resolver** and should be completed against the official bop.gov facility list.
- When a current, corroborated record is dropped *solely* because the facility state was unresolved, it's now logged (`DiagnosticLogger`, WARN) so catalog gaps surface instead of vanishing silently.
- The strict gate's behavior is otherwise unchanged: unresolved on either side still suppresses.

## Tests
- `BopFacilityCatalogTest`: code path (and unknown-code fall-through), word-order independence, punctuation independence, trailing-token resolution of an unknown city, non-trailing two-letter false-trigger guard, and unknown→null.
- `IdentityVerifierTest`: fixture gains a `faclCode` field (default blank, existing tests intact); a record with only a known code and a garbage name still passes the gate.

CI is the build/test gate (no Android SDK locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLM3y518hgoNGkNBFrbKSx)_